### PR TITLE
Intrinsic Enchants Merging

### DIFF
--- a/Matcha_Flavoured/data/main/advancement/mechanics/intrinsic_enchants_obtained.json
+++ b/Matcha_Flavoured/data/main/advancement/mechanics/intrinsic_enchants_obtained.json
@@ -1,0 +1,27 @@
+{
+	"parent": "main:mechanics/root",
+	"criteria": {
+		"obtained_intrinsic_enchants_item": {
+			"conditions": {
+				"items": [
+					{
+						"predicates": {
+							"minecraft:custom_data": {
+                                "has_intrinsic_enchants": 1
+                            }
+						}
+					}
+				]
+			},
+			"trigger": "minecraft:inventory_changed"
+		}
+	},
+	"requirements": [
+		[
+			"obtained_intrinsic_enchants_item"
+		]
+	],
+	"rewards": {
+		"function": "main:mechanic/intrinsic_enchants/process_intrinsic_enchants"
+	}
+}

--- a/Matcha_Flavoured/data/main/function/mechanic/intrinsic_enchants/apply_intrinsic_enchants.mcfunction
+++ b/Matcha_Flavoured/data/main/function/mechanic/intrinsic_enchants/apply_intrinsic_enchants.mcfunction
@@ -1,0 +1,6 @@
+$item modify entity @s container.$(slot) [{"function": "set_components", "components": {"minecraft:enchantments": $(enchantments), "!minecraft:stored_enchantments": {}}}, {"function": "set_custom_data", "tag": {"has_intrinsic_enchants": 0b}}]
+
+data remove storage minecraft:intrinsic_enchants slot
+data remove storage minecraft:intrinsic_enchants enchantments
+
+execute if items entity @s container.* *[minecraft:custom_data~{"has_intrinsic_enchants": 1b}] run function main:mechanic/intrinsic_enchants/process_intrinsic_enchants

--- a/Matcha_Flavoured/data/main/function/mechanic/intrinsic_enchants/process_intrinsic_enchants.mcfunction
+++ b/Matcha_Flavoured/data/main/function/mechanic/intrinsic_enchants/process_intrinsic_enchants.mcfunction
@@ -1,0 +1,84 @@
+advancement revoke @s only main:mechanics/intrinsic_enchants_obtained
+
+data modify storage minecraft:intrinsic_enchants item set from entity @s Inventory[{components: {"minecraft:custom_data": {"has_intrinsic_enchants": 1b}}}]
+
+data modify storage minecraft:intrinsic_enchants slot set from storage minecraft:intrinsic_enchants item.Slot
+data modify storage minecraft:intrinsic_enchants enchantments set value {}
+data modify storage minecraft:intrinsic_enchants enchantments merge from storage minecraft:intrinsic_enchants item.components.minecraft:enchantments
+
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:anemos"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:bloodrage"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:cleanse_armor_chest"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:cleanse_armor_feet"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:cleanse_armor_head"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:cleanse_armor_legs"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:cleanse_armor_maleffect"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:conduit_power"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:divinity"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:fire_proof"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:freezing_protection"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:haste"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:magic_protection"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:max_magic_protection"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:reach"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:regeneration"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:riposte"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:sanguine"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:shakudo_regen"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:slaughter"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:traversal"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:warding0"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:warding1"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:warding2"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:warding3"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:warding_armour"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "main:zephyr"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:aqua_affinity"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:bane_of_arthropods"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:binding_curse"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:blast_protection"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:breach"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:channeling"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:density"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:depth_strider"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:efficiency"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:feather_falling"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:fire_aspect"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:fire_protection"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:flame"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:fortune"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:frost_walker"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:impaling"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:infinity"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:knockback"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:looting"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:loyalty"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:luck_of_the_sea"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:lunge"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:lure"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:mending"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:multishot"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:piercing"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:power"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:projectile_protection"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:protection"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:punch"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:quick_charge"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:respiration"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:riptide"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:sharpness"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:silk_touch"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:smite"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:soul_speed"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:sweeping_edge"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:swift_sneak"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:thorns"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:unbreaking"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:vanishing_curse"}
+function main:mechanic/intrinsic_enchants/select_higher_level {"enchantment_id": "minecraft:wind_burst"}
+
+scoreboard players reset current intrinsic_enchants_levels
+scoreboard players reset intrinsic intrinsic_enchants_levels
+data remove storage minecraft:intrinsic_enchants item
+
+function main:mechanic/intrinsic_enchants/apply_intrinsic_enchants with storage minecraft:intrinsic_enchants

--- a/Matcha_Flavoured/data/main/function/mechanic/intrinsic_enchants/select_higher_level.mcfunction
+++ b/Matcha_Flavoured/data/main/function/mechanic/intrinsic_enchants/select_higher_level.mcfunction
@@ -1,0 +1,4 @@
+$execute store result score current intrinsic_enchants_levels run data get storage minecraft:intrinsic_enchants enchantments.$(enchantment_id)
+$execute store result score intrinsic intrinsic_enchants_levels run data get storage minecraft:intrinsic_enchants item.components.minecraft:stored_enchantments.$(enchantment_id)
+
+$execute if score current intrinsic_enchants_levels < intrinsic intrinsic_enchants_levels run data modify storage minecraft:intrinsic_enchants enchantments.$(enchantment_id) set from storage minecraft:intrinsic_enchants item.components.minecraft:stored_enchantments.$(enchantment_id)

--- a/Matcha_Flavoured/data/main/function/setup/scoreboard.mcfunction
+++ b/Matcha_Flavoured/data/main/function/setup/scoreboard.mcfunction
@@ -111,3 +111,6 @@ scoreboard players set easy difficulty_score 1
 scoreboard players set normal difficulty_score 2
 scoreboard players set hard difficulty_score 3
 execute store result score current_world_settings_difficulty difficulty_score run difficulty
+
+#Used in main/function/mechanic/intrinsic_enchants/
+scoreboard objectives add intrinsic_enchants_levels dummy

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_axe.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_axe.json
@@ -17,7 +17,10 @@
 				"default_mining_speed": 1,
 				"damage_per_block": 1
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:efficiency": 2,
 				"minecraft:unbreaking": 2
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_boots.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_boots.json
@@ -6,7 +6,10 @@
 		"id": "minecraft:netherite_boots",
 		"components": {
 			"minecraft:max_damage": 1000,
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:divinity": 1,
 				"minecraft:unbreaking": 2,
 				"minecraft:protection": 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_chestplate.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_chestplate.json
@@ -6,7 +6,10 @@
 		"id": "minecraft:netherite_chestplate",
 		"components": {
 			"minecraft:max_damage": 1000,
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:divinity": 1,
 				"minecraft:unbreaking": 2,
 				"minecraft:protection": 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_claymore.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_claymore.json
@@ -11,7 +11,10 @@
 				"color": "gold"
 			},
 			"minecraft:item_model": "minecraft:adamant_claymore",
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:unbreaking": 2,
 				"minecraft:sharpness": 1
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_dolabra.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_dolabra.json
@@ -27,7 +27,10 @@
 				"default_mining_speed": 1,
 				"damage_per_block": 1
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:unbreaking": 2,
 				"minecraft:efficiency": 1
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_helmet.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_helmet.json
@@ -6,7 +6,10 @@
 		"id": "minecraft:netherite_helmet",
 		"components": {
 			"minecraft:max_damage": 1000,
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:divinity": 1,
 				"minecraft:unbreaking": 2,
 				"minecraft:protection": 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_hoe.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_hoe.json
@@ -17,7 +17,10 @@
 				"default_mining_speed": 1,
 				"damage_per_block": 1
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:unbreaking": 2,
 				"minecraft:efficiency": 2
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_leggings.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_leggings.json
@@ -6,7 +6,10 @@
 		"id": "minecraft:netherite_leggings",
 		"components": {
 			"minecraft:max_damage": 1000,
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:divinity": 1,
 				"minecraft:unbreaking": 2,
 				"minecraft:protection": 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_mattock.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_mattock.json
@@ -22,7 +22,10 @@
 				"default_mining_speed": 1,
 				"damage_per_block": 1
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:efficiency": 1,
 				"minecraft:unbreaking": 2
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_pickaxe.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_pickaxe.json
@@ -22,7 +22,10 @@
 				"default_mining_speed": 1,
 				"damage_per_block": 1
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:efficiency": 2,
 				"minecraft:unbreaking": 2
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_shovel.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_shovel.json
@@ -17,7 +17,10 @@
 				"default_mining_speed": 1,
 				"damage_per_block": 1
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:efficiency": 2,
 				"minecraft:unbreaking": 2
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_spear.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_spear.json
@@ -49,7 +49,10 @@
 				]
 			},
 			"minecraft:enchantment_glint_override": false,
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:sharpness": 1,
 				"minecraft:unbreaking": 2
 			}

--- a/Matcha_Flavoured/data/main/recipe/smithing/adamant_sword.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/adamant_sword.json
@@ -10,7 +10,10 @@
 				"translate": "item.minecraft.netherite_sword",
 				"color": "gold"
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:sharpness": 1,
 				"minecraft:unbreaking": 2
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/bronze_boots.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/bronze_boots.json
@@ -53,7 +53,6 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {},
 			"minecraft:enchantment_glint_override": false,
 			"minecraft:item_model": "minecraft:bronze_boots",
 			"minecraft:equippable": {

--- a/Matcha_Flavoured/data/main/recipe/smithing/bronze_chestplate.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/bronze_chestplate.json
@@ -53,7 +53,6 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {},
 			"minecraft:enchantment_glint_override": false,
 			"minecraft:item_model": "minecraft:bronze_chestplate",
 			"minecraft:equippable": {

--- a/Matcha_Flavoured/data/main/recipe/smithing/bronze_elytra.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/bronze_elytra.json
@@ -58,7 +58,6 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {},
 			"minecraft:enchantment_glint_override": false,
 			"minecraft:item_model": "minecraft:bronze_elytra",
 			"minecraft:equippable": {

--- a/Matcha_Flavoured/data/main/recipe/smithing/bronze_helmet.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/bronze_helmet.json
@@ -53,7 +53,6 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {},
 			"minecraft:enchantment_glint_override": false,
 			"minecraft:item_model": "minecraft:bronze_helmet",
 			"minecraft:equippable": {

--- a/Matcha_Flavoured/data/main/recipe/smithing/bronze_leggings.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/bronze_leggings.json
@@ -53,7 +53,6 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {},
 			"minecraft:enchantment_glint_override": false,
 			"minecraft:item_model": "minecraft:bronze_leggings",
 			"minecraft:equippable": {

--- a/Matcha_Flavoured/data/main/recipe/smithing/bronze_spear.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/bronze_spear.json
@@ -66,7 +66,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:lunge": 3
 			},
 			"minecraft:repairable": {

--- a/Matcha_Flavoured/data/main/recipe/smithing/bronze_sword.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/bronze_sword.json
@@ -66,7 +66,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:riposte": 1
 			},
 			"minecraft:repairable": {

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_axe.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_axe.json
@@ -70,7 +70,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:fortune": 2,
 				"minecraft:looting": 2,
 				"minecraft:smite": 2,

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_boots.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_boots.json
@@ -68,7 +68,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:warding_armour": 1
 			},
 			"minecraft:item_model": "minecraft:electrum_boots",

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_chestplate.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_chestplate.json
@@ -68,7 +68,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:warding_armour": 1
 			},
 			"minecraft:item_model": "minecraft:electrum_chestplate",

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_dolabra.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_dolabra.json
@@ -80,7 +80,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:fortune": 2,
 				"main:warding1": 1,
 				"minecraft:looting": 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_helmet.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_helmet.json
@@ -68,7 +68,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:warding_armour": 1
 			},
 			"minecraft:item_model": "minecraft:electrum_helmet",

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_hoe.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_hoe.json
@@ -70,7 +70,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:fortune": 3,
 				"main:warding1": 1
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_leggings.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_leggings.json
@@ -68,7 +68,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:warding_armour": 1
 			},
 			"minecraft:item_model": "minecraft:electrum_leggings",

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_mattock.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_mattock.json
@@ -75,7 +75,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:fortune": 2,
 				"main:warding1": 1
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_pickaxe.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_pickaxe.json
@@ -75,7 +75,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:fortune": 3,
 				"main:warding1": 1
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_shovel.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_shovel.json
@@ -70,7 +70,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:fortune": 3,
 				"main:warding1": 1
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_spear.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_spear.json
@@ -47,7 +47,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:smite": 2,
 				"minecraft:looting": 2,
 				"main:warding2": 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/electrum_sword.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/electrum_sword.json
@@ -53,7 +53,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:looting": 2,
 				"minecraft:smite": 2,
 				"main:warding2": 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_axe.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_axe.json
@@ -22,7 +22,10 @@
 				"color": "#c96691"
 			},
 			"minecraft:item_model": "minecraft:shakudo_axe",
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:silk_touch": 1
 			},
 			"minecraft:lore": [

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_boots.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_boots.json
@@ -51,7 +51,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:cleanse_armor_feet": 1,
 				"main:magic_protection" : 1,
 				"main:shakudo_regen" : 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_chestplate.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_chestplate.json
@@ -51,7 +51,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:cleanse_armor_chest": 1,	
 				"main:magic_protection" : 1,
 				"main:shakudo_regen" : 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_dolabra.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_dolabra.json
@@ -27,7 +27,10 @@
 				"color": "#c96691"
 			},
 			"minecraft:item_model": "minecraft:shakudo_dolabra",
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:silk_touch": 1
 			},
 			"minecraft:lore": [

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_elytra.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_elytra.json
@@ -56,7 +56,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:max_magic_protection": 1,
 				"main:cleanse_armor_maleffect": 1,
 				"main:shakudo_regen" : 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_helmet.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_helmet.json
@@ -51,7 +51,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:cleanse_armor_head": 1,
 				"main:magic_protection" : 1,
 				"main:shakudo_regen" : 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_hoe.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_hoe.json
@@ -22,7 +22,10 @@
 				"color": "#c96691"
 			},
 			"minecraft:item_model": "minecraft:shakudo_hoe",
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:silk_touch": 1
 			},
 			"minecraft:lore": [

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_leggings.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_leggings.json
@@ -51,7 +51,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:cleanse_armor_legs": 1,
 				"main:magic_protection" : 1,
 				"main:shakudo_regen" : 1

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_mattock.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_mattock.json
@@ -54,7 +54,10 @@
 				"color": "#c96691"
 			},
 			"minecraft:item_model": "minecraft:shakudo_mattock",
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:silk_touch": 1
 			},
 			"minecraft:enchantment_glint_override": false,

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_pickaxe.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_pickaxe.json
@@ -27,7 +27,10 @@
 				"color": "#c96691"
 			},
 			"minecraft:item_model": "minecraft:shakudo_pickaxe",
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:silk_touch": 1
 			},
 			"minecraft:lore": [

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_shovel.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_shovel.json
@@ -22,7 +22,10 @@
 				"color": "#c96691"
 			},
 			"minecraft:item_model": "minecraft:shakudo_shovel",
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:silk_touch": 1
 			},
 			"minecraft:lore": [

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_spear.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_spear.json
@@ -59,7 +59,10 @@
 					"minecraft:copper_block"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:sanguine": 1
 			},
 			"minecraft:enchantment_glint_override": false

--- a/Matcha_Flavoured/data/main/recipe/smithing/shakudo_sword.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/shakudo_sword.json
@@ -27,7 +27,10 @@
 					"slot": "mainhand"
 				}
 			],
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:sweeping_edge": 1,
 				"main:sanguine": 1
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/silver_sword.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/silver_sword.json
@@ -55,7 +55,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:smite": 3,
 				"main:warding0": 1
 			},

--- a/Matcha_Flavoured/data/main/recipe/smithing/steel_boots.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/steel_boots.json
@@ -65,7 +65,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:blast_protection": 2
 			},
 			"minecraft:enchantment_glint_override": false,

--- a/Matcha_Flavoured/data/main/recipe/smithing/steel_chestplate.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/steel_chestplate.json
@@ -65,7 +65,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:blast_protection": 4
 			},
 			"minecraft:enchantment_glint_override": false,

--- a/Matcha_Flavoured/data/main/recipe/smithing/steel_helmet.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/steel_helmet.json
@@ -65,7 +65,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:blast_protection": 2
 			},
 			"minecraft:enchantment_glint_override": false,

--- a/Matcha_Flavoured/data/main/recipe/smithing/steel_leggings.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/steel_leggings.json
@@ -65,7 +65,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"minecraft:blast_protection": 3
 			},
 			"minecraft:enchantment_glint_override": false,

--- a/Matcha_Flavoured/data/main/recipe/smithing/steel_spear.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/steel_spear.json
@@ -70,7 +70,6 @@
 					"minecraft:iron_ingot"
 				]
 			},
-			"minecraft:enchantments": {},
 			"minecraft:enchantment_glint_override": false
 		}
 	}

--- a/Matcha_Flavoured/data/main/recipe/smithing/warding_shield.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/warding_shield.json
@@ -53,7 +53,10 @@
 					"minecraft:banner_patterns"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:warding1": 1
 			},
 			"minecraft:item_name": "Warding Shield",

--- a/Matcha_Flavoured/data/main/recipe/smithing/warding_sword.json
+++ b/Matcha_Flavoured/data/main/recipe/smithing/warding_sword.json
@@ -40,7 +40,10 @@
 					"minecraft:attribute_modifiers"
 				]
 			},
-			"minecraft:enchantments": {
+			"minecraft:custom_data": {
+                "has_intrinsic_enchants": 1
+			},
+			"minecraft:stored_enchantments": {
 				"main:warding0": 1
 			},
 			"minecraft:enchantment_glint_override": true,


### PR DESCRIPTION
### Overview
Allows intrinsic enchantments of items from smithing to be added to equipment without replacing enchantments already applied.
Ensures that the highest level of each enchantment is chosen.
Intrinsic enchantments are displayed on the result item alongside the original enchantments.

### How it works
Instead of directly setting the `enchantments` component in smithing recipes, the `stored_enchantments` component is set instead. The `custom_data` component is also set to include the `"has_intrinsic_enchants"` flag.
An advancement detects the `"has_intrinsic_enchants"` flag and runs a function with that player as @s.
The function stores the `enchantments` and `stored_enchantments` components of the item in command storage. These values are compared via scoreboard for each possible enchantment, selecting the higher level for each.
These enchantments are applied to the item via item modifier, and the `"has_intrinsic_enchants"` flag is removed.
The function is run again if the player has another item with the `"has_intrinsic_enchants"` flag.

### Notes
- To add enchantments to smithed items without merging, the enchantments should be set in the `stored_enchantments` component and the `"intrinsic_enchants"` flag should be added to the `custom_data` component:
```
"minecraft:custom_data": {
	"has_intrinsic_enchants": 1
},
"minecraft:stored_enchantments": {
	"minecraft:efficiency": 2,
	"minecraft:unbreaking": 2
}
```
- When adding a new enchantment (or removing an old one), a line must be added (or removed) in `data/main/function/mechanic/intrinsic_enchants/process_intrinsic_enchants.mcfunction` to add compatibility for it.
- This process should be made much simpler and dynamic by the data-driven number provider features of Minecraft 26.3 when updated.

- NOT tested in multiplayer, although it should work.