### PR TITLE
Enderman Anti-grief

### DIFF
--- a/Matcha_Flavoured/data/minecraft/tags/block/enderman_holdable.json
+++ b/Matcha_Flavoured/data/minecraft/tags/block/enderman_holdable.json
@@ -1,0 +1,8 @@
+{
+  "replace": true,
+  "values": [
+    "minecraft:melon",
+    "minecraft:pumpkin",
+    "minecraft:tnt"
+  ]
+}


### PR DESCRIPTION
Restricted Endermen to only be able to pick up Melons, Pumpkins and TNT