### PR TITLE
Fix skeleton serialization errors

### DIFF
--- a/Matcha_Flavoured/data/main/function/mechanic/spawn_mechanic/hard_modifications/modify_skeletons.mcfunction
+++ b/Matcha_Flavoured/data/main/function/mechanic/spawn_mechanic/hard_modifications/modify_skeletons.mcfunction
@@ -1,4 +1,2 @@
-
 attribute @s minecraft:max_health base set 12
-data merge entity @s {equipment:{mainhand:{id:"minecraft:bow",count:1,components:{"minecraft:enchantments":{"punch":0}}}}}
 data merge entity @s {equipment:{mainhand:{id:"minecraft:bow",count:1,components:{"minecraft:enchantments":{"punch":2}}}},drop_chances:{mainhand:0.000}}

--- a/Matcha_Flavoured/data/main/function/mechanic/spawn_mechanic/normal_modifications/modify_skeletons.mcfunction
+++ b/Matcha_Flavoured/data/main/function/mechanic/spawn_mechanic/normal_modifications/modify_skeletons.mcfunction
@@ -1,3 +1,2 @@
 attribute @s minecraft:max_health base set 10
-data merge entity @s {equipment:{mainhand:{id:"minecraft:bow",count:1,components:{"minecraft:enchantments":{"punch":0}}}}}
 data merge entity @s {equipment:{mainhand:{id:"minecraft:bow",count:1,components:{"minecraft:enchantments":{"punch":1}}}},drop_chances:{mainhand:0.000}}


### PR DESCRIPTION
Fixes #13
Removed the invalid Punch level 0 enchantment from the skeleton modification functions.
Punch 0 is not a valid enchantment level and was causing the entity equipment serialization warning.