### PR TITLE
Implementation Improvements for Anemos and Bloodrage enchantments

### DIFF
--- a/Matcha_Flavoured/data/main/function/enchantment_effects/anemos.mcfunction
+++ b/Matcha_Flavoured/data/main/function/enchantment_effects/anemos.mcfunction
@@ -1,10 +1,11 @@
-# I did it this way becuase I thought it would be easier to track an active effect on a player than by using a stopwatch? Am I dumb?
+# Abort this function if Anemos is on Cooldown
+execute if score @s AnemosCooldown matches 1.. run return fail
 
-# Hashiru: The nbt selector was replaced by a predicate, you also did it 3 times. this was reduced to 1 by moving the effect to another function
-execute unless predicate main:effects/has_unluck run function main:enchantment_effects/anemos_unluck
+execute anchored eyes run summon wind_charge ^ ^ ^.75 {Tags:["motion_projectile"]}
+execute as @n[tag=motion_projectile] at @s rotated as @p run function main:backend/apply_motion
 
-#This sets the windcharge to be owned by the player with the enchantment, which means advancments can detect it in the abbey!!!! Yessss! This took me so long, dude
+# Set the player's cooldown to 10 ticks, i.e. 0.5s, same as a normal Wind Charge
+scoreboard players add @s AnemosCooldown 10
+
+# This sets the Wind Charge to be owned by the player with the enchantment, which means advancements can detect it in the abbey!!!! Yessss! This took me so long, dude
 data modify entity @n[type=minecraft:wind_charge] Owner set from entity @s UUID
-
-#This makes the cool-down less than 1s, to 0.5s, same as a normal windcharge
-execute at @s run schedule function main:enchantment_effects/remove_anemos_maleffect 10t

--- a/Matcha_Flavoured/data/main/function/enchantment_effects/anemos_unluck.mcfunction
+++ b/Matcha_Flavoured/data/main/function/enchantment_effects/anemos_unluck.mcfunction
@@ -1,4 +1,0 @@
-# Hashiru: run the anemos effect and apply unluck
-execute at @s anchored eyes run summon wind_charge ^ ^ ^.75 {Tags:["motion_projectile"]}
-execute as @e[tag=motion_projectile] at @s rotated as @p run function main:backend/apply_motion
-effect give @s unluck 1 0 false

--- a/Matcha_Flavoured/data/main/function/enchantment_effects/bloodrage.mcfunction
+++ b/Matcha_Flavoured/data/main/function/enchantment_effects/bloodrage.mcfunction
@@ -1,3 +1,7 @@
-execute if entity @s[scores={HealthPoints=..10}] run effect give @s minecraft:resistance 1 1 true
-execute if entity @s[scores={HealthPoints=..10}] run effect give @s minecraft:strength 1 0 true
-execute if entity @s[scores={HealthPoints=..10}] run particle dust{color:[1.000,0.000,0.000],scale:1} ~ ~1.5 ~ .25 .25 .25 .1 1 normal
+# If the player has more than 10 health, stop the function without running the rest of the commands
+execute unless entity @s[scores={HealthPoints=..10}] run return fail
+
+# Apply Bloodrage
+effect give @s minecraft:resistance 1 1 true
+effect give @s minecraft:strength 1 0 true
+particle dust{color:[1.000,0.000,0.000],scale:1} ~ ~1.5 ~ .25 .25 .25 .1 1 normal

--- a/Matcha_Flavoured/data/main/function/setup/scoreboard.mcfunction
+++ b/Matcha_Flavoured/data/main/function/setup/scoreboard.mcfunction
@@ -54,13 +54,15 @@ stopwatch create shakudo_regen_6
 stopwatch create shakudo_regen_7
 stopwatch create shakudo_regen_8
 
+scoreboard objectives add AnemosCooldown dummy
+
 #Used mostly for particles
 stopwatch create 3s
 stopwatch create 2s
 stopwatch create 1s
 stopwatch create 0.5s
 
-#Used to clear xp after a cetain time after interacting with an anvil (cannot use schedule, as only the server can run schedule right now)
+#Used to clear xp after a certain time after interacting with an anvil (cannot use schedule, as only the server can run schedule right now)
 stopwatch create xp_timer
 
 #Used for village sounds
@@ -79,9 +81,9 @@ scoreboard players set 0 anvil_interaction 0
 scoreboard objectives add water_bucket_used minecraft.used:minecraft.water_bucket
 scoreboard players set 1 water_bucket_used 1
 
-#On load, set the wandering trader timer, and reset ALL people who summoned him, becuase if we dont, functions that should be looping wont be
-#and itll never ever fix itself. So if the server crashes, or someone logs out whilst waiting, they will never have a wandering trader arrive :c
-#We will also kill any existing wandering traders, on load. Because again, thatll mess things up
+#On load, set the wandering trader timer, and reset ALL people who summoned him, because if we don't, functions that should be looping wont be
+#and it'll never ever fix itself. So if the server crashes, or someone logs out whilst waiting, they will never have a wandering trader arrive :c
+#We will also kill any existing wandering traders, on load. Because again, that'll mess things up
 function main:mechanic/wandering_trader/kill_wandering_trader_early
 scoreboard objectives add wandering_trader_timer_score dummy
 scoreboard players reset @a wandering_trader_timer_score

--- a/Matcha_Flavoured/data/main/function/setup/tick.mcfunction
+++ b/Matcha_Flavoured/data/main/function/setup/tick.mcfunction
@@ -1,1 +1,3 @@
 function main:setup/ticking_functions
+
+execute as @a if score @s AnemosCooldown matches 1.. run scoreboard players remove @s AnemosCooldown 1


### PR DESCRIPTION
Anemos:
Now uses Scoreboards instead of the Unluck Effect to manage it's cooldown. Even though it uses a ticking command I am not concerned about performance as Scoreboards are one of the most efficient things to check and modify, probably more so than the effect method was.
* Now checks the cooldown before running any of the rest of the function, preventing any redundant commands from running
* No longer uses a schedule function for reducing the cooldown length, which should provide more consistent cooldown lengths in multiplayer
* No longer runs a function which isn't present in the Datapack! (For some reason main:enchantment_effects/remove_anemos_maleffect.mcfunction was missing!)

Bloodrage:
* Now only needs to check player health once