### PR TITLE
Bulk Block rework

### DIFF
--- a/Matcha_Flavoured/assets/minecraft/lang/en_au.json
+++ b/Matcha_Flavoured/assets/minecraft/lang/en_au.json
@@ -638,7 +638,7 @@
   "item.kleispack.tadpole": "Tadpole",
   "item.kleispack.bedrock_buster": "Bedrock Buster",
   "item.kleispack.warding_stone": "Warding Stone",
-  "item.kleispack.trade.bulk.desc": "Click on ground to unload",
+  "item.kleispack.trade.bulk.desc": "Use to unpack",
   "item.kleispack.trade.bulk_andesite": "Bulk Andesite",
   "item.kleispack.trade.bulk_andesite.desc": "x64 Andesite",
   "item.kleispack.trade.bulk_diorite": "Bulk Diorite",

--- a/Matcha_Flavoured/assets/minecraft/lang/en_ca.json
+++ b/Matcha_Flavoured/assets/minecraft/lang/en_ca.json
@@ -638,7 +638,7 @@
   "item.kleispack.tadpole": "Tadpole",
   "item.kleispack.bedrock_buster": "Bedrock Buster",
   "item.kleispack.warding_stone": "Warding Stone",
-  "item.kleispack.trade.bulk.desc": "Click on ground to unload",
+  "item.kleispack.trade.bulk.desc": "Use to unpack",
   "item.kleispack.trade.bulk_andesite": "Bulk Andesite",
   "item.kleispack.trade.bulk_andesite.desc": "x64 Andesite",
   "item.kleispack.trade.bulk_diorite": "Bulk Diorite",

--- a/Matcha_Flavoured/assets/minecraft/lang/en_gb.json
+++ b/Matcha_Flavoured/assets/minecraft/lang/en_gb.json
@@ -638,7 +638,7 @@
   "item.kleispack.tadpole": "Tadpole",
   "item.kleispack.bedrock_buster": "Bedrock Buster",
   "item.kleispack.warding_stone": "Warding Stone",
-  "item.kleispack.trade.bulk.desc": "Click on ground to unload",
+  "item.kleispack.trade.bulk.desc": "Use to unpack",
   "item.kleispack.trade.bulk_andesite": "Bulk Andesite",
   "item.kleispack.trade.bulk_andesite.desc": "x64 Andesite",
   "item.kleispack.trade.bulk_diorite": "Bulk Diorite",

--- a/Matcha_Flavoured/assets/minecraft/lang/en_nz.json
+++ b/Matcha_Flavoured/assets/minecraft/lang/en_nz.json
@@ -686,7 +686,7 @@
   "item.kleispack.tadpole": "Tadpole",
   "item.kleispack.bedrock_buster": "Bedrock Buster",
   "item.kleispack.warding_stone": "Warding Stone",
-  "item.kleispack.trade.bulk.desc": "Click on ground to unload",
+  "item.kleispack.trade.bulk.desc": "Use to unpack",
   "item.kleispack.trade.bulk_andesite": "Bulk Andesite",
   "item.kleispack.trade.bulk_andesite.desc": "x64 Andesite",
   "item.kleispack.trade.bulk_diorite": "Bulk Diorite",

--- a/Matcha_Flavoured/assets/minecraft/lang/en_pt.json
+++ b/Matcha_Flavoured/assets/minecraft/lang/en_pt.json
@@ -688,7 +688,7 @@
   "item.kleispack.tadpole": "Polliwog",
   "item.kleispack.bedrock_buster": "Buster o' bedrock",
   "item.kleispack.warding_stone": "Stone o' wardin'",
-  "item.kleispack.trade.bulk.desc": "Click on ground t' unload",
+  "item.kleispack.trade.bulk.desc": "Use t' spill",
   "item.kleispack.trade.bulk_andesite": "Bunch o' gray pebbles",
   "item.kleispack.trade.bulk_andesite.desc": "x64 Gray pebbles",
   "item.kleispack.trade.bulk_diorite": "Bunch o' white pebbles",

--- a/Matcha_Flavoured/assets/minecraft/lang/en_ud.json
+++ b/Matcha_Flavoured/assets/minecraft/lang/en_ud.json
@@ -688,7 +688,7 @@
   "item.kleispack.tadpole": "ǝꞁodpɐ⟘",
   "item.kleispack.bedrock_buster": "ɹǝʇsnᗺ ʞɔoɹpǝᗺ",
   "item.kleispack.warding_stone": "ǝuoʇS ᵷuᴉpɹɐM",
-  "item.kleispack.trade.bulk.desc": "pɐoꞁun oʇ punoɹᵷ uo ʞɔᴉꞁƆ",
+  "item.kleispack.trade.bulk.desc": "ʞɔɐdun oʇ ǝsꓵ",
   "item.kleispack.trade.bulk_andesite": "ǝʇᴉsǝpuⱯ ʞꞁnᗺ",
   "item.kleispack.trade.bulk_andesite.desc": "9߈ǝʇᴉsǝpuⱯ x",
   "item.kleispack.trade.bulk_diorite": "ǝʇᴉɹoᴉᗡ ʞꞁnᗺ",

--- a/Matcha_Flavoured/assets/minecraft/lang/en_us.json
+++ b/Matcha_Flavoured/assets/minecraft/lang/en_us.json
@@ -688,7 +688,7 @@
   "item.kleispack.tadpole": "Tadpole",
   "item.kleispack.bedrock_buster": "Bedrock Buster",
   "item.kleispack.warding_stone": "Warding Stone",
-  "item.kleispack.trade.bulk.desc": "Click on ground to unload",
+  "item.kleispack.trade.bulk.desc": "Use to unpack",
   "item.kleispack.trade.bulk_andesite": "Bulk Andesite",
   "item.kleispack.trade.bulk_andesite.desc": "x64 Andesite",
   "item.kleispack.trade.bulk_diorite": "Bulk Diorite",

--- a/Matcha_Flavoured/assets/minecraft/lang/enp.json
+++ b/Matcha_Flavoured/assets/minecraft/lang/enp.json
@@ -688,7 +688,7 @@
   "item.kleispack.tadpole": "Toadhead",
   "item.kleispack.bedrock_buster": "Bedstone Breaker",
   "item.kleispack.warding_stone": "Warding Stone",
-  "item.kleispack.trade.bulk.desc": "Click on ground to unload",
+  "item.kleispack.trade.bulk.desc": "Use to unpack",
   "item.kleispack.trade.bulk_andesite": "Bulk Andestone",
   "item.kleispack.trade.bulk_andesite.desc": "x64 Andestone",
   "item.kleispack.trade.bulk_diorite": "Bulk Shedstone",

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/andesite.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/andesite.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_andesite"
+                },
+                "minecraft:item_model": "minecraft:andesite",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_andesite.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:andesite",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/calcite.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/calcite.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_calcite"
+                },
+                "minecraft:item_model": "minecraft:calcite",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_calcite.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:calcite",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/deepslate.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/deepslate.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_deepslate"
+                },
+                "minecraft:item_model": "minecraft:deepslate",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_deepslate.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:deepslate",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/diorite.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/diorite.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_diorite"
+                },
+                "minecraft:item_model": "minecraft:diorite",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_diorite.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:diorite",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/flowstone.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/flowstone.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_dripstone"
+                },
+                "minecraft:item_model": "minecraft:dripstone_block",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_dripstone.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:dripstone_block",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/glass.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/glass.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_glass"
+                },
+                "minecraft:item_model": "minecraft:glass",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_glass.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:glass",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/granite.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/granite.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_granite"
+                },
+                "minecraft:item_model": "minecraft:granite",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_granite.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:granite",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/smooth_red_sandstone.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/smooth_red_sandstone.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_smooth_red_sandstone"
+                },
+                "minecraft:item_model": "minecraft:smooth_red_sandstone",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_smooth_red_sandstone.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:smooth_red_sandstone",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/smooth_sandstone.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/smooth_sandstone.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_smooth_sandstone"
+                },
+                "minecraft:item_model": "minecraft:smooth_sandstone",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_smooth_sandstone.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:smooth_sandstone",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/stone.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/stone.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_stone"
+                },
+                "minecraft:item_model": "minecraft:stone",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_stone.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:stone",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/loot_table/bulk_block/tuff.json
+++ b/Matcha_Flavoured/data/matcha/loot_table/bulk_block/tuff.json
@@ -1,0 +1,48 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:poisonous_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:item_name": {
+                  "translate": "item.kleispack.trade.bulk_tuff"
+                },
+                "minecraft:item_model": "minecraft:tuff",
+                "minecraft:lore": [
+                  {
+                    "translate": "item.kleispack.trade.bulk_tuff.desc",
+                    "color": "gray",
+                    "italic": false
+                  },
+                  {
+                    "translate": "item.kleispack.trade.bulk.desc",
+                    "color": "dark_gray",
+                    "italic": false
+                  }
+                ],
+                "!minecraft:food": {},
+                "minecraft:consumable": {
+                  "consume_seconds": 0,
+                  "sound": "minecraft:block.stone.fall",
+                  "has_consume_particles": false,
+                  "!on_consume_effects": {}
+                },
+                "use_remainder": {
+                  "id": "minecraft:tuff",
+                  "count": 64
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/1/andesite.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/1/andesite.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:andesite",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_andesite"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:andesite",
+				"count": 64
+			}
 		},
 		"count": 4
 	},

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/1/diorite.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/1/diorite.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:diorite",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_diorite"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:diorite",
+				"count": 64
+			}
 		},
 		"count": 4
 	},

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/1/granite.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/1/granite.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:granite",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_granite"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:granite",
+				"count": 64
+			}
 		},
 		"count": 4
 	},

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/1/stone.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/1/stone.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:stone",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_stone"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:stone",
+				"count": 64
+			}
 		},
 		"count": 4
 	},

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/2/deepslate.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/2/deepslate.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:deepslate",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_deepslate"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:deepslate",
+				"count": 64
+			}
 		},
 		"count": 2
 	},

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/2/glass.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/2/glass.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:glass",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_glass"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:glass",
+				"count": 64
+			}
 		},
 		"count": 3
 	},

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/2/smooth_red_sandstone.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/2/smooth_red_sandstone.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:smooth_red_sandstone",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_smooth_red_sandstone"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:smooth_red_sandstone",
+				"count": 64
+			}
 		},
 		"count": 2
 	},

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/2/smooth_sandstone.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/2/smooth_sandstone.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:smooth_sandstone",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_smooth_sandstone"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:smooth_sandstone",
+				"count": 64
+			}
 		},
 		"count": 2
 	},

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/2/tuff.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/2/tuff.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:tuff",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_tuff"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:tuff",
+				"count": 64
+			}
 		},
 		"count": 2
 	},

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/3/calcite.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/3/calcite.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:calcite",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_calcite"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:calcite",
+				"count": 64
+			}
 		},
 		"count": 2
 	},

--- a/Matcha_Flavoured/data/matcha/villager_trade/mason/3/flowstone.json
+++ b/Matcha_Flavoured/data/matcha/villager_trade/mason/3/flowstone.json
@@ -1,14 +1,7 @@
 {
 	"gives": {
-		"id": "minecraft:chicken_spawn_egg",
+		"id": "minecraft:poisonous_potato",
 		"components": {
-			"minecraft:entity_data": {
-				"id": "minecraft:item",
-				"Item": {
-					"id": "minecraft:dripstone_block",
-					"count": 64
-				}
-			},
 			"minecraft:item_name": {
 				"translate": "item.kleispack.trade.bulk_dripstone"
 			},
@@ -24,7 +17,18 @@
 					"color": "dark_gray",
 					"italic": false
 				}
-			]
+			],
+			"!minecraft:food": {},
+			"minecraft:consumable": {
+				"consume_seconds": 0,
+				"sound": "minecraft:block.stone.fall",
+				"has_consume_particles": false,
+				"!on_consume_effects": {}
+			},
+			"use_remainder": {
+				"id": "minecraft:dripstone_block",
+				"count": 64
+			}
 		},
 		"count": 2
 	},


### PR DESCRIPTION
Now unpacked with a right click instead of placing a stack of items on the ground
* Using the item anywhere unpacks it
* Items appear directly in your inventory if you have space
* Now plays an unpacking sound

This implementation uses a poisonous potato with a use_remainder of a stack of blocks (same mechanism as getting a glass bottle from consuming pickles) instead of a spawn egg