### PR TITLE
fix: use correct key to merge entity data to prevent log spam

### DIFF
--- a/Matcha_Flavoured/data/matcha/function/mechanic/spawn_mechanic/hard_modifications/modify_skeletons.mcfunction
+++ b/Matcha_Flavoured/data/matcha/function/mechanic/spawn_mechanic/hard_modifications/modify_skeletons.mcfunction
@@ -1,2 +1,2 @@
 attribute @s minecraft:max_health base set 12
-data merge entity @s {equipment:{mainhand:{id:"minecraft:bow",count:1,components:{"minecraft:enchantments":{"punch":2}}}},drop_chances:{mainhand:0.000}}
+data merge entity @s {equipment:{mainhand:{id:"minecraft:bow",count:1,components:{"minecraft:enchantments":{"minecraft:punch":2}}}},drop_chances:{mainhand:0.000}}

--- a/Matcha_Flavoured/data/matcha/function/mechanic/spawn_mechanic/normal_modifications/modify_skeletons.mcfunction
+++ b/Matcha_Flavoured/data/matcha/function/mechanic/spawn_mechanic/normal_modifications/modify_skeletons.mcfunction
@@ -1,2 +1,2 @@
 attribute @s minecraft:max_health base set 10
-data merge entity @s {equipment:{mainhand:{id:"minecraft:bow",count:1,components:{"minecraft:enchantments":{"punch":1}}}},drop_chances:{mainhand:0.000}}
+data merge entity @s {equipment:{mainhand:{id:"minecraft:bow",count:1,components:{"minecraft:enchantments":{"minecraft:punch":1}}}},drop_chances:{mainhand:0.000}}


### PR DESCRIPTION
I updated the functions to modify the skeletons so that they use the correct key for the punch enchantment. The data could not be merged when there was already a punch enchantment because the key differed to the one skeletons spawn with. That resulted in a conflict that was logged. 