### PR TITLE
refactor water bottle stacking to be more optimized

### DIFF
--- a/Matcha_Flavoured/data/matcha/advancement/update_vanilla_item/water_bottle.json
+++ b/Matcha_Flavoured/data/matcha/advancement/update_vanilla_item/water_bottle.json
@@ -1,0 +1,23 @@
+{
+  "criteria": {
+    "has_water_bottle": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:potion",
+            "components": {
+              "minecraft:potion_contents": {
+                "potion": "minecraft:water"
+              },
+              "minecraft:max_stack_size": 1
+            }
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function":	"matcha:mechanic/water_bottle_stacking"
+  }
+}

--- a/Matcha_Flavoured/data/matcha/function/mechanic/water_bottle_stacking.mcfunction
+++ b/Matcha_Flavoured/data/matcha/function/mechanic/water_bottle_stacking.mcfunction
@@ -1,4 +1,3 @@
-execute at @a run execute if items entity @p inventory.* minecraft:potion[potion_contents={potion:"minecraft:water"},!max_stack_size=64] run give @p minecraft:potion[potion_contents={potion:"minecraft:water"},max_stack_size=64]
-execute at @a run execute if items entity @p hotbar.* minecraft:potion[potion_contents={potion:"minecraft:water"},!max_stack_size=64] run give @p minecraft:potion[potion_contents={potion:"minecraft:water"},max_stack_size=64]
-execute at @a run execute if items entity @p inventory.* minecraft:potion[potion_contents={potion:"minecraft:water"},!max_stack_size=64] run clear @p minecraft:potion[potion_contents={potion:"minecraft:water"},!max_stack_size=64]
-execute at @a run execute if items entity @p hotbar.* minecraft:potion[potion_contents={potion:"minecraft:water"},!max_stack_size=64] run clear @p minecraft:potion[potion_contents={potion:"minecraft:water"},!max_stack_size=64]
+advancement revoke @s only matcha:update_vanilla_item/water_bottle
+give @s minecraft:potion[potion_contents={potion:"minecraft:water"},max_stack_size=64]
+clear @s minecraft:potion[potion_contents={potion:"minecraft:water"},!max_stack_size=64]

--- a/Matcha_Flavoured/data/matcha/function/setup/ticking_functions.mcfunction
+++ b/Matcha_Flavoured/data/matcha/function/setup/ticking_functions.mcfunction
@@ -1,6 +1,5 @@
 function matcha:mechanic/sleeping/tick
 function matcha:mechanic/manage_hunger
-function matcha:mechanic/water_bottle_stacking
 function matcha:mechanic/warding_stone/warding_stone
 function matcha:mechanic/spawn_mechanic/ticking
 function matcha:mechanic/anvil_xp/remove_xp


### PR DESCRIPTION
You currently check every hotbar and inventory slot for vanilla water bottles every tick. I changed two things:

First, I added a new advancement that triggers on an inventory change involving a vanilla water bottle, with the `water_bottle_stacking` function as its reward.

Second, I removed the old checks. Now the function just removes the vanilla water bottle and gives back the matcha one.

I verified that the function doesn't give bottles to other players and that it works when you walk into a pile of vanilla water bottles.