### PR TITLE
fix: adjust weight of enchanted golden apple to be as in vanilla

### DIFF
--- a/data/minecraft/loot_table/chests/ruined_portal.json
+++ b/data/minecraft/loot_table/chests/ruined_portal.json
@@ -111,7 +111,7 @@
 				{
 					"type": "minecraft:loot_table",
 					"value": "minecraft:food/enchanted_golden_apple",
-					"weight": 80
+					"weight": 1
 				},
 				{
 					"type": "minecraft:item",


### PR DESCRIPTION
It seems that the weight of the enchanted golden apple was increased per accident, maybe copy paste error?