### PR TITLE
Split Zephyr enchantment effects across three levels

### DIFF
--- a/data/matcha/enchantment/zephyr.json
+++ b/data/matcha/enchantment/zephyr.json
@@ -11,51 +11,6 @@
 					"entity": "this",
 					"predicate": {
 						"flags": {
-							"is_sneaking": false,
-							"is_on_ground": false
-						},
-						"effects": {
-							"minecraft:slow_falling": {}
-						}
-					}
-				},
-				"effect": {
-					"type": "minecraft:all_of",
-					"effects": [
-						{
-							"type": "minecraft:run_function",
-							"function": "matcha:enchantment_effects/zephyr_execute"
-						}
-					]
-				}
-			},
-			{
-				"requirements": {
-					"condition": "minecraft:entity_properties",
-					"entity": "this",
-					"predicate": {
-						"flags": {
-							"is_sneaking": false,
-							"is_on_ground": false
-						}
-					}
-				},
-				"effect": {
-					"type": "minecraft:all_of",
-					"effects": [
-						{
-							"type": "minecraft:run_function",
-							"function": "matcha:enchantment_effects/zephyr_failure"
-						}
-					]
-				}
-			},
-			{
-				"requirements": {
-					"condition": "minecraft:entity_properties",
-					"entity": "this",
-					"predicate": {
-						"flags": {
 							"is_sneaking": true
 						}
 					}
@@ -74,14 +29,6 @@
 							"max_duration": 0.25,
 							"min_amplifier": 6,
 							"max_amplifier": 6
-						},
-						{
-							"type": "minecraft:apply_mob_effect",
-							"to_apply": "minecraft:slow_falling",
-							"min_duration": 0.25,
-							"max_duration": 0.25,
-							"min_amplifier": 1,
-							"max_amplifier": 1
 						},
 						{
 							"type": "minecraft:spawn_particles",
@@ -106,6 +53,117 @@
 						}
 					]
 				}
+			},
+			{
+				"requirements": {
+					"condition": "minecraft:all_of",
+					"terms": [
+						{
+							"condition": "minecraft:entity_properties",
+							"entity": "this",
+							"predicate": {
+								"flags": {
+									"is_sneaking": true
+								}
+							}
+						},
+						{
+							"condition": "minecraft:value_check",
+							"value": {
+								"type": "minecraft:enchantment_level",
+								"amount": {
+									"type": "minecraft:linear",
+									"base": 1,
+									"per_level_above_first": 1
+								}
+							},
+							"range": {
+								"min": 2
+							}
+						}
+					]
+				},
+				"effect": {
+					"type": "minecraft:apply_mob_effect",
+					"to_apply": "minecraft:slow_falling",
+					"min_duration": 0.25,
+					"max_duration": 0.25,
+					"min_amplifier": 1,
+					"max_amplifier": 1
+				}
+			},
+			{
+				"requirements": {
+					"condition": "minecraft:all_of",
+					"terms": [
+						{
+							"condition": "minecraft:entity_properties",
+							"entity": "this",
+							"predicate": {
+								"flags": {
+									"is_sneaking": false,
+									"is_on_ground": false
+								},
+								"effects": {
+									"minecraft:slow_falling": {}
+								}
+							}
+						},
+						{
+							"condition": "minecraft:value_check",
+							"value": {
+								"type": "minecraft:enchantment_level",
+								"amount": {
+									"type": "minecraft:linear",
+									"base": 1,
+									"per_level_above_first": 1
+								}
+							},
+							"range": {
+								"min": 3
+							}
+						}
+					]
+				},
+				"effect": {
+					"type": "minecraft:run_function",
+					"function": "matcha:enchantment_effects/zephyr_execute"
+				}
+			},
+			{
+				"requirements": {
+					"condition": "minecraft:all_of",
+					"terms": [
+						{
+							"condition": "minecraft:entity_properties",
+							"entity": "this",
+							"predicate": {
+								"flags": {
+									"is_sneaking": false,
+									"is_on_ground": false
+								}
+							}
+						},
+						{
+							"condition": "minecraft:value_check",
+							"value": {
+								"type": "minecraft:enchantment_level",
+								"amount": {
+									"type": "minecraft:linear",
+									"base": 1,
+									"per_level_above_first": 1
+								}
+							},
+							"range": {
+								"min": 3
+							}
+						}
+					]
+				},
+				"effect": {
+					"type": "minecraft:run_function",
+					"function": "matcha:enchantment_effects/zephyr_failure"
+				}
 			}
 		]
 	},
@@ -113,7 +171,7 @@
 		"base": 15,
 		"per_level_above_first": 0
 	},
-	"max_level": 1,
+	"max_level": 3,
 	"min_cost": {
 		"base": 1,
 		"per_level_above_first": 0

--- a/data/matcha/function/enchantment_effects/zephyr.mcfunction
+++ b/data/matcha/function/enchantment_effects/zephyr.mcfunction
@@ -1,2 +1,2 @@
-execute if score @p sneaking matches 45 run particle minecraft:dust_plume ~ ~ ~ .5 .1 .5 .1 50
-execute if score @p sneaking matches 45 run playsound minecraft:entity.experience_orb.pickup player @p ~ ~ ~ 0.75
+execute if score @s sneaking matches 45 run particle minecraft:dust_plume ~ ~ ~ .5 .1 .5 .1 50
+execute if score @s sneaking matches 45 run playsound minecraft:entity.experience_orb.pickup player @s ~ ~ ~ 0.75

--- a/data/matcha/function/enchantment_effects/zephyr_failure.mcfunction
+++ b/data/matcha/function/enchantment_effects/zephyr_failure.mcfunction
@@ -1,1 +1,1 @@
-scoreboard players set @p sneaking 0
+scoreboard players set @s sneaking 0


### PR DESCRIPTION
Rework the Zephyr enchantment from a single-level enchantment into a three-level enchantment with effects unlocked incrementally.
Update Zephyr's functions to use `@s` instead of `@p`

Closes #29