### PR TITLE
Fix uninitialized Hearts score reducing maximum health

### DIFF
--- a/Matcha_Flavoured_RDP/data/matcha/function/setup/scoreboard.mcfunction
+++ b/Matcha_Flavoured_RDP/data/matcha/function/setup/scoreboard.mcfunction
@@ -17,7 +17,8 @@ scoreboard objectives add HealthPoints health
 scoreboard objectives add deaths deathCount
 scoreboard players set 1 deaths 1
 scoreboard objectives add Hearts dummy
-scoreboard players add @a Hearts 0
+scoreboard players add @a Hearts 20
+scoreboard players set @a[scores={Hearts=0}] Hearts 20
 
 scoreboard objectives add minimum_hearts dummy
 scoreboard players add @a minimum_hearts 0


### PR DESCRIPTION
Fix #43 

### 

The `Hearts` is currently initialized with:

```mcfunction
scoreboard players add @a Hearts 0
```

For a new player, this creates a `Hearts` score of `0`. If the player does not die or use a Crystal Heart, that score remains at zero while world progression gradually lowers `current_minimum_hearts`.

When the player eventually receives and consumes their first Crystal Heart:

1. `clear_heart_container` adds 2 to their `Hearts` score.
2. Their score changes from `0` to `2`, instead of from the intended starting value of `20` to `22`.
3. `set_max_hp` detects that `2` is below `current_minimum_hearts`.
4. The score is raised to the current minimum rather than to the player's correct maximum health.

For example, if `current_minimum_hearts` has reached `10`, the player's maximum health is set to 10 health points, or 5 hearts. The same bug can produce 9, 8, 7, or 6 hearts if it is first triggered at an earlier progression stage.

Death can expose the same initialization problem because it also modifies the player's `Hearts` score before calling `set_max_hp`.

### Fix

After creating missing scoreboard entries, initialize players whose score is still zero to the intended starting value of 20:

```mcfunction
scoreboard players add @a Hearts 20
scoreboard players set @a[scores={Hearts=0}] Hearts 20
```

A valid player health score cannot be zero: the mechanic enforces a minimum of at least 6 health points. It is therefore safe to treat zero as an uninitialized value.

This preserves every existing non-zero score, including health gained from Crystal Hearts and health lost through deaths.

### I'm already affected 😭😭😭

The automatic fix can repair players whose `Hearts` score is still zero. However, once the bug has triggered, `set_max_hp` replaces the zero-derived value with the current minimum, such as 18, 16, 14, 12, or 10.

At that point, the stored value is indistinguishable from a legitimate value caused by player deaths, so affected players cannot be identified or restored automatically.

#### e.g. Commands for `v1.12.1-alpha`

```mcfunction
/scoreboard players set <player> Hearts 22
/execute as <player> run function main:mechanic/heart_container/set_max_hp
```

Replace `22` with the calculated value when you have previously consumed other Crystal Hearts or lost health through deaths.

Optionally, heal yourself after restoring their maximum health:

```mcfunction
/effect give <player> minecraft:regeneration 3 10 true
```