### PR TITLE
Making Matcha Flavoured loadable by Fabric

### DIFF
--- a/Matcha_Flavoured_RDP/fabric.mod.json
+++ b/Matcha_Flavoured_RDP/fabric.mod.json
@@ -1,0 +1,21 @@
+{
+    "schemaVersion": 1,
+    "id": "matcha-flavoured",
+    "version": "1.12.2",
+    "name": "Matcha Flavoured",
+    "description": "Reworks minecraft's gameplay to benefit slower, less technical players",
+    "authors": [
+        "klei_wright"
+    ],
+    "contact": {
+        "homepage": "https://modrinth.com/datapack/matcha-flavoured",
+        "sources": "https://github.com/kleiwright/matcha-flavoured",
+        "issues": "https://github.com/kleiwright/matcha-flavoured/issues"
+    },
+    "license": "CC-BY-NC-SA-4.0",
+    "icon": "pack.png",
+    "environment": "*",
+    "depends": {
+        "minecraft": "~26.2"
+    }
+}


### PR DESCRIPTION
Hi, Klei! Not sure if this is what you wanna do, but hear me out.

With this file inside you will be able to simply rename your .zip file into a .jar file, which will make it a valid Fabric mod. You can distribute it as an additional version on Modrinth alongside the data/resource pack version.

This mod version will make it a lot easier for people to install and update Matcha without having to manually enabling the resource pack and adding the data pack to each world, as Fabric will load them both automatically.
Also, for me and all other mod devs, the mod version will make it much easier to load it as a dependency and build some stuff on top of Matcha.

The only issue with this approach is that people won't be able to use alternative resource packs (like Matcha Vanilla Flavoured). But that's for more technical people anyway I guess, and it will still be possible to just use the data pack version for that.