### PR TITLE
fixed shakudo sword asset in weaponsmith trade

### DIFF
--- a/MF_datapack/data/matcha/villager_trade/weaponsmith/2/shakudo_sword.json
+++ b/MF_datapack/data/matcha/villager_trade/weaponsmith/2/shakudo_sword.json
@@ -2,7 +2,7 @@
 	"wants": {
 		"id": "minecraft:stone_sword",
 		"components": {
-			"minecraft:item_model": "matcha:palatinate_sword"
+			"minecraft:item_model": "matcha:shakudo_sword"
 		},
 		"count": 1
 	},


### PR DESCRIPTION
The shakudo sword's asset has been renamed by a recent commit, so I have updated the reference to it in the weaponsmith villager trade.