### PR TITLE
Update loot tables

### DIFF
--- a/MF_datapack/data/matcha/advancement/end/smith_bronze_elytra.json
+++ b/MF_datapack/data/matcha/advancement/end/smith_bronze_elytra.json
@@ -1,10 +1,10 @@
 {
 	"parent": "matcha:end/elytra",
 	"criteria": {
-		"bronze_elytra": {
+		"hepatizon_elytra": {
 			"trigger": "minecraft:recipe_crafted",
 			"conditions": {
-				"recipe_id": "smithing_table:bronze_elytra"
+				"recipe_id": "matcha:smithing/hepatizon_elytra"
 			}
 		}
 	},
@@ -21,7 +21,7 @@
 		],
 		"icon": {
 			"components": {
-				"minecraft:item_model": "minecraft:bronze_elytra"
+				"minecraft:item_model": "matcha:hepatizon_elytra"
 			},
 			"count": 1,
 			"id": "minecraft:elytra"
@@ -34,7 +34,7 @@
 	},
 	"requirements": [
 		[
-			"bronze_elytra"
+			"hepatizon_elytra"
 		]
 	],
     "rewards": {

--- a/MF_datapack/data/matcha/advancement/end/smith_shakudo_elytra.json
+++ b/MF_datapack/data/matcha/advancement/end/smith_shakudo_elytra.json
@@ -4,7 +4,7 @@
 		"shakudo_elytra": {
 			"trigger": "minecraft:recipe_crafted",
 			"conditions": {
-				"recipe_id": "smithing_table:shakudo_elytra"
+				"recipe_id": "matcha:smithing/shakudo_elytra"
 			}
 		}
 	},
@@ -21,7 +21,7 @@
 		],
 		"icon": {
 			"components": {
-				"minecraft:item_model": "minecraft:shakudo_elytra"
+				"minecraft:item_model": "matcha:shakudo_elytra"
 			},
 			"count": 1,
 			"id": "minecraft:elytra"

--- a/MF_datapack/data/matcha/function/mechanic/heart_container/clear_heart_container.mcfunction
+++ b/MF_datapack/data/matcha/function/mechanic/heart_container/clear_heart_container.mcfunction
@@ -5,10 +5,10 @@
 
 scoreboard players add @s Hearts 2
 effect give @s regeneration 3 10 true
-clear @s *[minecraft:item_model="minecraft:heart_container"] 1
+clear @s *[minecraft:item_model="matcha:heart_container"] 1
 
 # Hashiru: Play the sound only if there is no more heart remaining in the inventory to prevent 10 sounds playing at once and destroying my eardrums
-execute unless items entity @s container.* *[minecraft:item_model="minecraft:heart_container"] run playsound minecraft:item.totem.use player @a ~ ~ ~ .5 0 0
+execute unless items entity @s container.* *[minecraft:item_model="matcha:heart_container"] run playsound minecraft:item.totem.use player @a ~ ~ ~ .5 0 0
 
 advancement revoke @p only matcha:mechanics/heart_container_obtained
 
@@ -16,4 +16,4 @@ advancement revoke @p only matcha:mechanics/heart_container_obtained
 execute if score @s Hearts >= maximum_hearts Hearts run advancement grant @s only matcha:with_songs/max_health
 
 #If they still have the Crystal Heart, run the function again
-execute if items entity @s container.* *[minecraft:item_model="minecraft:heart_container"] run function matcha:mechanic/heart_container/process_heart_container
+execute if items entity @s container.* *[minecraft:item_model="matcha:heart_container"] run function matcha:mechanic/heart_container/process_heart_container

--- a/MF_datapack/data/matcha/loot_table/advancement/crystal_heart_1.json
+++ b/MF_datapack/data/matcha/loot_table/advancement/crystal_heart_1.json
@@ -12,7 +12,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:heart_container",
+								"minecraft:item_model": "matcha:heart_container",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.crystal_heart"
 								},

--- a/MF_datapack/data/matcha/loot_table/advancement/crystal_heart_2.json
+++ b/MF_datapack/data/matcha/loot_table/advancement/crystal_heart_2.json
@@ -12,7 +12,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:heart_container",
+								"minecraft:item_model": "matcha:heart_container",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.crystal_heart"
 								},

--- a/MF_datapack/data/matcha/loot_table/advancement/obol_1.json
+++ b/MF_datapack/data/matcha/loot_table/advancement/obol_1.json
@@ -17,5 +17,5 @@
 			]
 		}
 	],
-	"random_sequence": "main:advancement/reward"
+	"random_sequence": "matcha:advancement/reward"
 }

--- a/MF_datapack/data/matcha/loot_table/advancement/obol_10.json
+++ b/MF_datapack/data/matcha/loot_table/advancement/obol_10.json
@@ -17,5 +17,5 @@
 			]
 		}
 	],
-	"random_sequence": "main:advancement/reward"
+	"random_sequence": "matcha:advancement/reward"
 }

--- a/MF_datapack/data/matcha/loot_table/advancement/obol_2.json
+++ b/MF_datapack/data/matcha/loot_table/advancement/obol_2.json
@@ -17,5 +17,5 @@
 			]
 		}
 	],
-	"random_sequence": "main:advancement/reward"
+	"random_sequence": "matcha:advancement/reward"
 }

--- a/MF_datapack/data/matcha/loot_table/advancement/obol_3.json
+++ b/MF_datapack/data/matcha/loot_table/advancement/obol_3.json
@@ -17,5 +17,5 @@
 			]
 		}
 	],
-	"random_sequence": "main:advancement/reward"
+	"random_sequence": "matcha:advancement/reward"
 }

--- a/MF_datapack/data/matcha/loot_table/advancement/obol_4.json
+++ b/MF_datapack/data/matcha/loot_table/advancement/obol_4.json
@@ -17,5 +17,5 @@
 			]
 		}
 	],
-	"random_sequence": "main:advancement/reward"
+	"random_sequence": "matcha:advancement/reward"
 }

--- a/MF_datapack/data/matcha/loot_table/advancement/obol_5.json
+++ b/MF_datapack/data/matcha/loot_table/advancement/obol_5.json
@@ -17,5 +17,5 @@
 			]
 		}
 	],
-	"random_sequence": "main:advancement/reward"
+	"random_sequence": "matcha:advancement/reward"
 }

--- a/MF_datapack/data/matcha/loot_table/archaeology/statues.json
+++ b/MF_datapack/data/matcha/loot_table/archaeology/statues.json
@@ -54,5 +54,5 @@
 			"rolls": 1
 		}
 	],
-	"random_sequence": "minecraft:archealogy/statues"
+	"random_sequence": "matcha:archealogy/statues"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/amber.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/amber.json
@@ -7,13 +7,16 @@
 			"entries": [
 				{
 					"type": "minecraft:item",
-					"name": "minecraft:turtle_scute",
+					"name": "minecraft:fermented_spider_eye",
 					"functions": [
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:enchantment_glint_override": true,
-								"minecraft:rarity": "rare"
+								"minecraft:item_model": "matcha:amber",
+								"minecraft:item_name": {
+									"translate": "item.kleispack.amber",
+									"color": "gold"
+								}
 							}
 						}
 					]
@@ -21,5 +24,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/avesta.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/avesta.json
@@ -9,23 +9,17 @@
 					"type": "minecraft:item",
 					"name": "minecraft:book",
 					"weight": 1,
+					"conditions": [],
 					"functions": [
 						{
 							"function": "minecraft:set_components",
 							"components": {
 								"minecraft:item_name": {
-									"translate": "item.kleispack.key_of_solomon"
+									"translate": "item.kleispack.avesta"
 								},
-								"minecraft:rarity": "epic",
+								"minecraft:rarity": "rare",
 								"minecraft:max_stack_size": 64,
-								"minecraft:item_model": "minecraft:solomon",
-								"minecraft:lore": [
-									{
-										"translate": "item.kleispack.key_of_solomon.desc",
-										"color": "gray",
-										"italic": false
-									}
-								]
+								"minecraft:item_model": "matcha:avesta"
 							}
 						}
 					]
@@ -33,5 +27,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/crystal_heart.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/crystal_heart.json
@@ -7,20 +7,18 @@
 			"entries": [
 				{
 					"type": "minecraft:item",
-					"name": "minecraft:turtle_scute",
+					"name": "minecraft:poisonous_potato",
 					"functions": [
 						{
 							"function": "minecraft:set_components",
 							"components": {
+								"minecraft:item_model": "matcha:heart_container",
+								"minecraft:item_name": {
+									"translate": "item.kleispack.crystal_heart"
+								},
+								"minecraft:rarity": "rare",
 								"minecraft:enchantment_glint_override": true,
-								"minecraft:rarity": "rare"
-							}
-						},
-						{
-							"function": "minecraft:set_count",
-							"count": {
-								"min": 1,
-								"max": 3
+								"!minecraft:consumable": {}
 							}
 						}
 					]
@@ -28,5 +26,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/divine_comedy.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/divine_comedy.json
@@ -8,21 +8,19 @@
 				{
 					"type": "minecraft:item",
 					"name": "minecraft:book",
-					"weight": 1,
-					"conditions": [],
 					"functions": [
 						{
 							"function": "minecraft:set_components",
 							"components": {
 								"minecraft:item_name": {
-									"translate": "item.kleispack.tanakh"
+									"translate": "item.kleispack.divine_comedy"
 								},
-								"minecraft:rarity": "rare",
+								"minecraft:rarity": "uncommon",
 								"minecraft:max_stack_size": 64,
-								"minecraft:item_model": "minecraft:tanakh",
+								"minecraft:item_model": "matcha:divine_comedy",
 								"minecraft:lore": [
 									{
-										"translate": "item.kleispack.tanakh.desc",
+										"translate": "item.kleispack.divine_comedy.desc",
 										"color": "gray",
 										"italic": false
 									}
@@ -34,5 +32,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/divine_fragment.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/divine_fragment.json
@@ -7,16 +7,13 @@
 			"entries": [
 				{
 					"type": "minecraft:item",
-					"name": "minecraft:fermented_spider_eye",
+					"name": "minecraft:turtle_scute",
 					"functions": [
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:amber",
-								"minecraft:item_name": {
-									"translate": "item.kleispack.amber",
-									"color": "gold"
-								}
+								"minecraft:enchantment_glint_override": true,
+								"minecraft:rarity": "rare"
 							}
 						}
 					]
@@ -24,5 +21,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/divine_fragment_poly.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/divine_fragment_poly.json
@@ -7,18 +7,20 @@
 			"entries": [
 				{
 					"type": "minecraft:item",
-					"name": "minecraft:poisonous_potato",
+					"name": "minecraft:turtle_scute",
 					"functions": [
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:heart_container",
-								"minecraft:item_name": {
-									"translate": "item.kleispack.crystal_heart"
-								},
-								"minecraft:rarity": "rare",
 								"minecraft:enchantment_glint_override": true,
-								"!minecraft:consumable": {}
+								"minecraft:rarity": "rare"
+							}
+						},
+						{
+							"function": "minecraft:set_count",
+							"count": {
+								"min": 1,
+								"max": 3
 							}
 						}
 					]
@@ -26,5 +28,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/enoch.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/enoch.json
@@ -13,14 +13,14 @@
 							"function": "minecraft:set_components",
 							"components": {
 								"minecraft:item_name": {
-									"translate": "item.kleispack.paradise_lost"
+									"translate": "item.kleispack.enoch"
 								},
-								"minecraft:rarity": "uncommon",
+								"minecraft:rarity": "rare",
 								"minecraft:max_stack_size": 64,
-								"minecraft:item_model": "minecraft:paradise_lost",
+								"minecraft:item_model": "matcha:enoch",
 								"minecraft:lore": [
 									{
-										"translate": "item.kleispack.paradise_lost.desc",
+										"translate": "item.kleispack.enoch.desc",
 										"color": "gray",
 										"italic": false
 									}
@@ -32,5 +32,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/gnocchi_recipe.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/gnocchi_recipe.json
@@ -14,7 +14,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-                                "minecraft:item_model": "minecraft:gnocchi_recipe",
+                                "minecraft:item_model": "matcha:gnocchi_recipe",
                                 "minecraft:item_name": {
                                     "translate": "item.kleispack.cooking_recipe"
                                 },
@@ -32,5 +32,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/opal.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/opal.json
@@ -12,10 +12,10 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:topaz",
+								"minecraft:item_model": "matcha:opal",
 								"minecraft:item_name": {
-									"translate": "item.kleispack.topaz",
-									"color": "yellow"
+									"translate": "item.kleispack.opal",
+									"color": "#ab85ad"
 								}
 							}
 						}
@@ -24,5 +24,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/paradise_lost.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/paradise_lost.json
@@ -8,18 +8,23 @@
 				{
 					"type": "minecraft:item",
 					"name": "minecraft:book",
-					"weight": 1,
-					"conditions": [],
 					"functions": [
 						{
 							"function": "minecraft:set_components",
 							"components": {
 								"minecraft:item_name": {
-									"translate": "item.kleispack.avesta"
+									"translate": "item.kleispack.paradise_lost"
 								},
-								"minecraft:rarity": "rare",
+								"minecraft:rarity": "uncommon",
 								"minecraft:max_stack_size": 64,
-								"minecraft:item_model": "minecraft:avesta"
+								"minecraft:item_model": "matcha:paradise_lost",
+								"minecraft:lore": [
+									{
+										"translate": "item.kleispack.paradise_lost.desc",
+										"color": "gray",
+										"italic": false
+									}
+								]
 							}
 						}
 					]
@@ -27,5 +32,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/quran.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/quran.json
@@ -19,10 +19,10 @@
 								},
 								"minecraft:rarity": "rare",
 								"minecraft:max_stack_size": 64,
-								"minecraft:item_model": "minecraft:quran",
+								"minecraft:item_model": "matcha:quran",
 								"minecraft:lore": [
 									{
-										"text": "القرآن",
+										"translate": "item.kleispack.quran.desc",
 										"color": "gray",
 										"italic": false
 									}
@@ -34,5 +34,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/ruby.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/ruby.json
@@ -12,7 +12,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:ruby",
+								"minecraft:item_model": "matcha:ruby",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.ruby",
 									"color": "red"
@@ -24,5 +24,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/solomon.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/solomon.json
@@ -8,19 +8,20 @@
 				{
 					"type": "minecraft:item",
 					"name": "minecraft:book",
+					"weight": 1,
 					"functions": [
 						{
 							"function": "minecraft:set_components",
 							"components": {
 								"minecraft:item_name": {
-									"translate": "item.kleispack.enoch"
+									"translate": "item.kleispack.key_of_solomon"
 								},
-								"minecraft:rarity": "rare",
+								"minecraft:rarity": "epic",
 								"minecraft:max_stack_size": 64,
-								"minecraft:item_model": "minecraft:enoch",
+								"minecraft:item_model": "matcha:solomon",
 								"minecraft:lore": [
 									{
-										"translate": "item.kleispack.enoch.desc",
+										"translate": "item.kleispack.key_of_solomon.desc",
 										"color": "gray",
 										"italic": false
 									}
@@ -32,5 +33,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/tanakh.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/tanakh.json
@@ -8,19 +8,21 @@
 				{
 					"type": "minecraft:item",
 					"name": "minecraft:book",
+					"weight": 1,
+					"conditions": [],
 					"functions": [
 						{
 							"function": "minecraft:set_components",
 							"components": {
 								"minecraft:item_name": {
-									"translate": "item.kleispack.divine_comedy"
+									"translate": "item.kleispack.tanakh"
 								},
-								"minecraft:rarity": "uncommon",
+								"minecraft:rarity": "rare",
 								"minecraft:max_stack_size": 64,
-								"minecraft:item_model": "minecraft:divine_comedy",
+								"minecraft:item_model": "matcha:tanakh",
 								"minecraft:lore": [
 									{
-										"translate": "item.kleispack.divine_comedy.desc",
+										"translate": "item.kleispack.tanakh.desc",
 										"color": "gray",
 										"italic": false
 									}
@@ -32,5 +34,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/kleis_items/topaz.json
+++ b/MF_datapack/data/matcha/loot_table/kleis_items/topaz.json
@@ -12,10 +12,10 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:opal",
+								"minecraft:item_model": "matcha:topaz",
 								"minecraft:item_name": {
-									"translate": "item.kleispack.opal",
-									"color": "#ab85ad"
+									"translate": "item.kleispack.topaz",
+									"color": "yellow"
 								}
 							}
 						}
@@ -24,5 +24,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/matcha/loot_table/treasure/crystal_heart.json
+++ b/MF_datapack/data/matcha/loot_table/treasure/crystal_heart.json
@@ -11,7 +11,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:heart_container",
+								"minecraft:item_model": "matcha:heart_container",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.crystal_heart"
 								},

--- a/MF_datapack/data/matcha/loot_table/treasure/quran.json
+++ b/MF_datapack/data/matcha/loot_table/treasure/quran.json
@@ -21,7 +21,7 @@
 								"minecraft:item_model": "matcha:quran",
 								"minecraft:lore": [
 									{
-										"text": "القرآن",
+										"translate": "item.kleispack.quran.desc",
 										"color": "gray",
 										"italic": false
 									}

--- a/MF_datapack/data/minecraft/loot_table/archaeology/abbey/grave.json
+++ b/MF_datapack/data/minecraft/loot_table/archaeology/abbey/grave.json
@@ -34,7 +34,7 @@
 							"function": "minecraft:set_components",
 							"components": {
 								"!minecraft:consumable": {},
-								"minecraft:item_model": "minecraft:wooden_cross",
+								"minecraft:item_model": "matcha:wooden_cross",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.wooden_cross",
 									"color": "white"
@@ -51,7 +51,7 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:archaeology/statues",
+					"value": "matcha:archaeology/statues",
 					"quality": 1
 				}
 			],

--- a/MF_datapack/data/minecraft/loot_table/archaeology/desert_well.json
+++ b/MF_datapack/data/minecraft/loot_table/archaeology/desert_well.json
@@ -31,11 +31,11 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:archaeology/statues"
+					"value": "matcha:archaeology/statues"
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/avesta"
+					"value": "matcha:kleis_items/avesta"
 				}
 			],
 			"rolls": 1

--- a/MF_datapack/data/minecraft/loot_table/archaeology/ocean_ruin_cold.json
+++ b/MF_datapack/data/minecraft/loot_table/archaeology/ocean_ruin_cold.json
@@ -27,7 +27,7 @@
 							"function": "minecraft:set_components",
 							"components": {
 								"minecraft:damage": 140,
-								"minecraft:item_model": "minecraft:rusty_axe",
+								"minecraft:item_model": "matcha:rusty_axe",
 								"minecraft:item_name": "Rusty Axe",
 								"minecraft:lore": [
 									{

--- a/MF_datapack/data/minecraft/loot_table/archaeology/ocean_ruin_warm.json
+++ b/MF_datapack/data/minecraft/loot_table/archaeology/ocean_ruin_warm.json
@@ -47,7 +47,7 @@
 							"function": "minecraft:set_components",
 							"components": {
 								"minecraft:damage": 140,
-								"minecraft:item_model": "minecraft:rusty_axe",
+								"minecraft:item_model": "matcha:rusty_axe",
 								"minecraft:item_name": "Rusty Axe",
 								"minecraft:lore": [
 									{

--- a/MF_datapack/data/minecraft/loot_table/archaeology/trail_ruins_rare.json
+++ b/MF_datapack/data/minecraft/loot_table/archaeology/trail_ruins_rare.json
@@ -58,11 +58,11 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/amber"
+					"value": "matcha:kleis_items/amber"
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:archaeology/statues"
+					"value": "matcha:archaeology/statues"
 				}
 			],
 			"rolls": 1

--- a/MF_datapack/data/minecraft/loot_table/archaeology/village_plains.json
+++ b/MF_datapack/data/minecraft/loot_table/archaeology/village_plains.json
@@ -40,7 +40,7 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:archaeology/statues",
+					"value": "matcha:archaeology/statues",
 					"quality": 1
 				}
 			],

--- a/MF_datapack/data/minecraft/loot_table/chests/abandoned_mineshaft.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/abandoned_mineshaft.json
@@ -33,7 +33,7 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/gnocchi_recipe",
+					"value": "matcha:kleis_items/gnocchi_recipe",
 					"weight": 5
 				}
 			],

--- a/MF_datapack/data/minecraft/loot_table/chests/abbey/barracks.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/abbey/barracks.json
@@ -184,7 +184,7 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/crystal_heart",
+					"value": "matcha:kleis_items/crystal_heart",
 					"weight": 33,
 					"quality": 1
 				}

--- a/MF_datapack/data/minecraft/loot_table/chests/abbey/tower.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/abbey/tower.json
@@ -19,7 +19,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:compound_bow",
+								"minecraft:item_model": "matcha:compound_bow",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.compound_bow"
 								},

--- a/MF_datapack/data/minecraft/loot_table/chests/ancient_city.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/ancient_city.json
@@ -301,19 +301,19 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/topaz",
+					"value": "matcha:kleis_items/topaz",
 					"weight": 5,
 					"quality": 1
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/crystal_heart",
+					"value": "matcha:kleis_items/crystal_heart",
 					"weight": 2,
 					"quality": 1
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/divine_fragment_poly",
+					"value": "matcha:kleis_items/divine_fragment_poly",
 					"weight": 2,
 					"quality": 2
 				}

--- a/MF_datapack/data/minecraft/loot_table/chests/bastion_bridge.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/bastion_bridge.json
@@ -6,7 +6,7 @@
 			"entries": [
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/ruby"
+					"value": "matcha:kleis_items/ruby"
 				}
 			]
 		},

--- a/MF_datapack/data/minecraft/loot_table/chests/bastion_hoglin_stable.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/bastion_hoglin_stable.json
@@ -6,7 +6,7 @@
 			"entries": [
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/ruby"
+					"value": "matcha:kleis_items/ruby"
 				}
 			]
 		},

--- a/MF_datapack/data/minecraft/loot_table/chests/bastion_treasure.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/bastion_treasure.json
@@ -6,7 +6,7 @@
 			"entries": [
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/ruby"
+					"value": "matcha:kleis_items/ruby"
 				}
 			]
 		},

--- a/MF_datapack/data/minecraft/loot_table/chests/equipment/special_compass.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/equipment/special_compass.json
@@ -13,7 +13,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:titanium_compass",
+								"minecraft:item_model": "matcha:titanium_compass",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.titanium_compass"
 								}
@@ -29,7 +29,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:golden_compass",
+								"minecraft:item_model": "matcha:golden_compass",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.golden_compass"
 								}
@@ -44,7 +44,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:copper_compass",
+								"minecraft:item_model": "matcha:copper_compass",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.copper_compass"
 								}
@@ -55,5 +55,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/chests/equipment/sturdy_leather.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/equipment/sturdy_leather.json
@@ -48,7 +48,7 @@
 								"minecraft:enchantments": {
 									"minecraft:projectile_protection": 3
 								},
-								"minecraft:item_model": "minecraft:sturdy_leather_helmet",
+								"minecraft:item_model": "matcha:sturdy_leather_helmet",
 								"minecraft:equippable": {
 									"slot": "head",
 									"asset_id": "minecraft:sturdy_leather"
@@ -110,7 +110,7 @@
 								"minecraft:enchantments": {
 									"minecraft:projectile_protection": 4
 								},
-								"minecraft:item_model": "minecraft:sturdy_leather_chestplate",
+								"minecraft:item_model": "matcha:sturdy_leather_chestplate",
 								"minecraft:equippable": {
 									"slot": "chest",
 									"asset_id": "minecraft:sturdy_leather"
@@ -172,7 +172,7 @@
 								"minecraft:enchantments": {
 									"minecraft:projectile_protection": 3
 								},
-								"minecraft:item_model": "minecraft:sturdy_leather_leggings",
+								"minecraft:item_model": "matcha:sturdy_leather_leggings",
 								"minecraft:equippable": {
 									"slot": "legs",
 									"asset_id": "minecraft:sturdy_leather"
@@ -236,7 +236,7 @@
 									"minecraft:feather_falling": 3,
 									"matcha:traversal": 1
 								},
-								"minecraft:item_model": "minecraft:sturdy_leather_boots",
+								"minecraft:item_model": "matcha:sturdy_leather_boots",
 								"minecraft:equippable": {
 									"slot": "feet",
 									"asset_id": "minecraft:sturdy_leather"

--- a/MF_datapack/data/minecraft/loot_table/chests/equipment/trident.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/equipment/trident.json
@@ -50,5 +50,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/chests/igloo_chest.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/igloo_chest.json
@@ -24,7 +24,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:tallow",
+								"minecraft:item_model": "matcha:tallow",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.tallow"
 								}

--- a/MF_datapack/data/minecraft/loot_table/chests/stronghold_corridor.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/stronghold_corridor.json
@@ -107,7 +107,7 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/divine_fragment",
+					"value": "matcha:kleis_items/divine_fragment",
 					"weight": 1
 				},
 				{
@@ -118,7 +118,7 @@
 							"function": "minecraft:set_components",
 							"components": {
 								"minecraft:jukebox_playable": "matcha:labyrinthine",
-								"minecraft:item_model": "minecraft:music_disc_labyrinthine"
+								"minecraft:item_model": "matcha:music_disc_labyrinthine"
 							}
 						}
 					]

--- a/MF_datapack/data/minecraft/loot_table/chests/trial_chambers/reward_ominous_rare.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/trial_chambers/reward_ominous_rare.json
@@ -92,7 +92,7 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/divine_fragment",
+					"value": "matcha:kleis_items/divine_fragment",
 					"weight": 1
 				}
 			],

--- a/MF_datapack/data/minecraft/loot_table/chests/trial_chambers/reward_ominous_unique.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/trial_chambers/reward_ominous_unique.json
@@ -19,12 +19,12 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/divine_fragment",
+					"value": "matcha:kleis_items/divine_fragment",
 					"weight": 1
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/crystal_heart",
+					"value": "matcha:kleis_items/crystal_heart",
 					"weight": 1
 				}
 			],

--- a/MF_datapack/data/minecraft/loot_table/chests/trial_chambers/reward_unique.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/trial_chambers/reward_unique.json
@@ -30,7 +30,7 @@
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/crystal_heart",
+					"value": "matcha:kleis_items/crystal_heart",
 					"weight": 1
 				}
 			],

--- a/MF_datapack/data/minecraft/loot_table/chests/village/village_temple.json
+++ b/MF_datapack/data/minecraft/loot_table/chests/village/village_temple.json
@@ -85,17 +85,17 @@
 			"entries": [
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/tanakh",
+					"value": "matcha:kleis_items/tanakh",
 					"weight": 1
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/avesta",
+					"value": "matcha:kleis_items/avesta",
 					"weight": 1
 				},
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/quran",
+					"value": "matcha:kleis_items/quran",
 					"weight": 1
 				}
 			]

--- a/MF_datapack/data/minecraft/loot_table/entities/elder_guardian.json
+++ b/MF_datapack/data/minecraft/loot_table/entities/elder_guardian.json
@@ -22,7 +22,7 @@
 			"entries": [
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/divine_fragment_poly"
+					"value": "matcha:kleis_items/divine_fragment_poly"
 				}
 			],
 			"rolls": 1
@@ -47,7 +47,7 @@
 			"entries": [
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/opal"
+					"value": "matcha:kleis_items/opal"
 				}
 			],
 			"conditions": [

--- a/MF_datapack/data/minecraft/loot_table/entities/evoker.json
+++ b/MF_datapack/data/minecraft/loot_table/entities/evoker.json
@@ -48,7 +48,7 @@
 			"entries": [
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/divine_fragment"
+					"value": "matcha:kleis_items/divine_fragment"
 				}
 			],
 			"conditions": [

--- a/MF_datapack/data/minecraft/loot_table/entities/piglin_brute.json
+++ b/MF_datapack/data/minecraft/loot_table/entities/piglin_brute.json
@@ -6,7 +6,7 @@
 			"entries": [
 				{
 					"type": "minecraft:loot_table",
-					"value": "minecraft:kleis_items/divine_fragment"
+					"value": "matcha:kleis_items/divine_fragment"
 				}
 			],
 			"conditions": [

--- a/MF_datapack/data/minecraft/loot_table/entities/sulfur_cube.json
+++ b/MF_datapack/data/minecraft/loot_table/entities/sulfur_cube.json
@@ -45,7 +45,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:sulfur_goo",
+								"minecraft:item_model": "matcha:sulfur_goo",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.sulfur_goo"
 								}

--- a/MF_datapack/data/minecraft/loot_table/food/apple.json
+++ b/MF_datapack/data/minecraft/loot_table/food/apple.json
@@ -49,5 +49,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/apple_empanada.json
+++ b/MF_datapack/data/minecraft/loot_table/food/apple_empanada.json
@@ -19,7 +19,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-                                "minecraft:item_model": "minecraft:apple_empanada",
+                                "minecraft:item_model": "matcha:apple_empanada",
                                 "minecraft:item_name": {
                                     "translate": "item.kleispack.apple_empanada"
                                 },
@@ -74,5 +74,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/baked_potato.json
+++ b/MF_datapack/data/minecraft/loot_table/food/baked_potato.json
@@ -57,5 +57,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/bread.json
+++ b/MF_datapack/data/minecraft/loot_table/food/bread.json
@@ -78,5 +78,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/bruschetta.json
+++ b/MF_datapack/data/minecraft/loot_table/food/bruschetta.json
@@ -19,7 +19,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-                                "minecraft:item_model": "minecraft:bruschetta",
+                                "minecraft:item_model": "matcha:bruschetta",
                                 "minecraft:item_name": {
                                     "translate": "item.kleispack.bruschetta"
                                 },
@@ -75,5 +75,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/carrot.json
+++ b/MF_datapack/data/minecraft/loot_table/food/carrot.json
@@ -50,5 +50,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/enchanted_golden_apple.json
+++ b/MF_datapack/data/minecraft/loot_table/food/enchanted_golden_apple.json
@@ -103,5 +103,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/glow_berries.json
+++ b/MF_datapack/data/minecraft/loot_table/food/glow_berries.json
@@ -49,5 +49,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/glow_jam.json
+++ b/MF_datapack/data/minecraft/loot_table/food/glow_jam.json
@@ -19,7 +19,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-                                "minecraft:item_model": "minecraft:glow_jam",
+                                "minecraft:item_model": "matcha:glow_jam",
                                 "minecraft:item_name": {
                                     "translate": "item.kleispack.glow_berry_jam"
                                 },
@@ -73,5 +73,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/golden_apple.json
+++ b/MF_datapack/data/minecraft/loot_table/food/golden_apple.json
@@ -77,5 +77,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/golden_carrot.json
+++ b/MF_datapack/data/minecraft/loot_table/food/golden_carrot.json
@@ -72,5 +72,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/mead.json
+++ b/MF_datapack/data/minecraft/loot_table/food/mead.json
@@ -19,7 +19,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:mead",
+								"minecraft:item_model": "matcha:mead",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.mead"
 								},
@@ -78,5 +78,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/milk_bottle.json
+++ b/MF_datapack/data/minecraft/loot_table/food/milk_bottle.json
@@ -54,5 +54,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/pickled_carrots.json
+++ b/MF_datapack/data/minecraft/loot_table/food/pickled_carrots.json
@@ -19,7 +19,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-                                "minecraft:item_model": "minecraft:pickled_carrots",
+                                "minecraft:item_model": "matcha:pickled_carrots",
                                 "minecraft:item_name": {
                                     "translate": "item.kleispack.pickled_carrots"
                                 },
@@ -77,5 +77,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/pumpkin_empanada.json
+++ b/MF_datapack/data/minecraft/loot_table/food/pumpkin_empanada.json
@@ -19,7 +19,7 @@
 						{
 							"function": "minecraft:set_components",
 							"components": {
-								"minecraft:item_model": "minecraft:pumpkin_empanada",
+								"minecraft:item_model": "matcha:pumpkin_empanada",
 								"minecraft:item_name": {
 									"translate": "item.kleispack.pumpkin_empanada"
 								},
@@ -75,5 +75,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }

--- a/MF_datapack/data/minecraft/loot_table/food/sweet_berries.json
+++ b/MF_datapack/data/minecraft/loot_table/food/sweet_berries.json
@@ -50,5 +50,5 @@
 			]
 		}
 	],
-	"random_sequence": "minecraft:kleis_items"
+	"random_sequence": "matcha:kleis_items"
 }


### PR DESCRIPTION
Moved klei_items and archaeology/statues loot tables to matcha namespace.
Updated many references in loot tables.
Updated references in crystal heart function.
Updated references in shakudo and bronze elytra smithing advancements.