### PR TITLE
Corrected abbey/grave archaeology loot table

### DIFF
--- a/MF_datapack/data/minecraft/loot_table/archaeology/abbey/grave.json
+++ b/MF_datapack/data/minecraft/loot_table/archaeology/abbey/grave.json
@@ -1,5 +1,5 @@
 {
-	"type": "minecraft:chest",
+	"type": "minecraft:archaeology",
 	"pools": [
 		{
 			"entries": [
@@ -40,7 +40,7 @@
 									"color": "white"
 								},
 								"minecraft:enchantments": {
-									"matcha:warding0": 1
+									"matcha:warding_1": 1
 								},
 								"minecraft:enchantment_glint_override": false
 							}


### PR DESCRIPTION
Updated wooden cross item modifier in the `minecraft:archaeology/abbey/grave` loot table.
Also changed the table type to archaeology.