### PR TITLE
Forbidden spawns kept in same chunk when killed

### DIFF
--- a/MF_datapack/data/matcha/function/mechanic/spawn_mechanic/safe_surface.mcfunction
+++ b/MF_datapack/data/matcha/function/mechanic/spawn_mechanic/safe_surface.mcfunction
@@ -3,7 +3,7 @@ execute at @s run execute if dimension minecraft:overworld run execute if predic
 # I dont think Camel Jockeys spawn underground, but just in-case, ill remove them
 execute at @s run execute if dimension minecraft:overworld run execute if predicate matcha:mob_checks/is_husk if predicate matcha:riding_camel_husk run function matcha:mechanic/spawn_mechanic/remove_camel_husk_jockey
 execute at @s run execute if dimension minecraft:overworld run execute if predicate matcha:drowned_surface_spawn run tag @s add SpawnForbidden
-execute as @s[tag=SpawnForbidden] run tp @s ~ ~-1000 ~
+execute as @s[tag=SpawnForbidden] at @s run tp @s ~ ~-1000 ~
 execute as @s[tag=SpawnForbidden] run kill @s
 execute as @s run execute if entity @s[tag=!SpawnForbidden] run function matcha:mechanic/spawn_mechanic/modify_mob
 tag @s add SpawnChecked


### PR DESCRIPTION
This should fix the issue of mobs being teleported to unloaded chunks (so that they cannot be killed), and causing lag when the chunk becomes loaded.