### PR TITLE
Reload Hearts Fix

### DIFF
--- a/MF_datapack/data/matcha/function/setup/scoreboard.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/scoreboard.mcfunction
@@ -17,7 +17,7 @@ scoreboard objectives add HealthPoints health
 scoreboard objectives add deaths deathCount
 scoreboard players set 1 deaths 1
 scoreboard objectives add Hearts dummy
-scoreboard players add @a Hearts 20
+scoreboard players add @a Hearts 0
 scoreboard players set @a[scores={Hearts=0}] Hearts 20
 
 scoreboard objectives add minimum_hearts dummy


### PR DESCRIPTION
Corrected the adding of 10 to each players' `Hearts` score on load.
(Made known by @Linkershim in #78.)