### PR TITLE
Use timeline for extending time

### DIFF
--- a/MF_datapack/data/matcha/function/environmental/day_cycle_extender.mcfunction
+++ b/MF_datapack/data/matcha/function/environmental/day_cycle_extender.mcfunction
@@ -1,3 +1,0 @@
-time add 1
-#This resets the function, such that one tick of day time advances every 3-4? ticks, idk
-schedule function matcha:environmental/day_cycle_extender 3t

--- a/MF_datapack/data/matcha/function/environmental/load_day_cycle_extender.mcfunction
+++ b/MF_datapack/data/matcha/function/environmental/load_day_cycle_extender.mcfunction
@@ -1,1 +1,0 @@
-function main:environmental/day_cycle_extender

--- a/MF_datapack/data/matcha/function/setup/gamerules.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/gamerules.mcfunction
@@ -1,5 +1,5 @@
 gamerule natural_health_regeneration false
-gamerule advance_time false
+gamerule advance_time true
 gamerule spawn_phantoms false
 gamerule keep_inventory true
 gamerule block_explosion_drop_decay false

--- a/MF_datapack/data/matcha/function/setup/load.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/load.mcfunction
@@ -1,5 +1,4 @@
 # Set up functions
-function matcha:environmental/load_day_cycle_extender
 function matcha:setup/scoreboard
 
 # Print information to players

--- a/MF_datapack/data/minecraft/timeline/day.json
+++ b/MF_datapack/data/minecraft/timeline/day.json
@@ -1,34 +1,34 @@
 {
-	"period_ticks": 24000,
+	"period_ticks": 72000,
 	"clock": "minecraft:overworld",
 	"time_markers": {
 		"minecraft:day": {
 			"show_in_commands": true,
-			"ticks": 1000
+			"ticks": 3000
 		},
 		"minecraft:midnight": {
 			"show_in_commands": true,
-			"ticks": 18000
+			"ticks": 54000
 		},
 		"minecraft:night": {
 			"show_in_commands": true,
-			"ticks": 13000
+			"ticks": 39000
 		},
 		"minecraft:noon": {
 			"show_in_commands": true,
-			"ticks": 6000
+			"ticks": 18000
 		},
-		"minecraft:roll_village_siege": 18000
+		"minecraft:roll_village_siege": 54000
 	},
 	"tracks": {
 		"minecraft:audio/firefly_bush_sounds": {
 			"keyframes": [
 				{
-					"ticks": 12600,
+					"ticks": 37800,
 					"value": true
 				},
 				{
-					"ticks": 23401,
+					"ticks": 70203,
 					"value": false
 				}
 			],
@@ -37,11 +37,11 @@
 		"minecraft:gameplay/bees_stay_in_hive": {
 			"keyframes": [
 				{
-					"ticks": 12542,
+					"ticks": 37626,
 					"value": true
 				},
 				{
-					"ticks": 23460,
+					"ticks": 70380,
 					"value": false
 				}
 			],
@@ -51,11 +51,11 @@
 			"ease": "constant",
 			"keyframes": [
 				{
-					"ticks": 362,
+					"ticks": 1086,
 					"value": 0
 				},
 				{
-					"ticks": 23667,
+					"ticks": 71001,
 					"value": 0.7
 				}
 			],
@@ -64,11 +64,11 @@
 		"minecraft:gameplay/creaking_active": {
 			"keyframes": [
 				{
-					"ticks": 12600,
+					"ticks": 37800,
 					"value": true
 				},
 				{
-					"ticks": 23401,
+					"ticks": 70203,
 					"value": false
 				}
 			],
@@ -77,11 +77,11 @@
 		"minecraft:gameplay/eyeblossom_open": {
 			"keyframes": [
 				{
-					"ticks": 12600,
+					"ticks": 37800,
 					"value": true
 				},
 				{
-					"ticks": 23401,
+					"ticks": 70203,
 					"value": false
 				}
 			]
@@ -89,11 +89,11 @@
 		"minecraft:gameplay/monsters_burn": {
 			"keyframes": [
 				{
-					"ticks": 12542,
+					"ticks": 37626,
 					"value": false
 				},
 				{
-					"ticks": 23460,
+					"ticks": 70380,
 					"value": true
 				}
 			],
@@ -102,19 +102,19 @@
 		"minecraft:gameplay/sky_light_level": {
 			"keyframes": [
 				{
-					"ticks": 133,
+					"ticks": 399,
 					"value": 1
 				},
 				{
-					"ticks": 11867,
+					"ticks": 35601,
 					"value": 1
 				},
 				{
-					"ticks": 13670,
+					"ticks": 41010,
 					"value": 0.26666668
 				},
 				{
-					"ticks": 22330,
+					"ticks": 66990,
 					"value": 0.26666668
 				}
 			],
@@ -124,11 +124,11 @@
 			"ease": "constant",
 			"keyframes": [
 				{
-					"ticks": 21062,
+					"ticks": 63186,
 					"value": 1
 				},
 				{
-					"ticks": 21905,
+					"ticks": 65715,
 					"value": 0.002
 				}
 			],
@@ -137,19 +137,19 @@
 		"minecraft:visual/cloud_color": {
 			"keyframes": [
 				{
-					"ticks": 133,
+					"ticks": 399,
 					"value": -1
 				},
 				{
-					"ticks": 11867,
+					"ticks": 35601,
 					"value": -1
 				},
 				{
-					"ticks": 13670,
+					"ticks": 41010,
 					"value": -15132378
 				},
 				{
-					"ticks": 22330,
+					"ticks": 66990,
 					"value": -15132378
 				}
 			],
@@ -158,19 +158,19 @@
 		"minecraft:visual/fog_color": {
 			"keyframes": [
 				{
-					"ticks": 133,
+					"ticks": 399,
 					"value": "#ffffff"
 				},
 				{
-					"ticks": 11867,
+					"ticks": 35601,
 					"value": "#ffffff"
 				},
 				{
-					"ticks": 13670,
+					"ticks": 41010,
 					"value": "#0f0f16"
 				},
 				{
-					"ticks": 22330,
+					"ticks": 66990,
 					"value": "#0f0f16"
 				}
 			],
@@ -179,19 +179,19 @@
 		"minecraft:visual/sky_color": {
 			"keyframes": [
 				{
-					"ticks": 133,
+					"ticks": 399,
 					"value": "#ffffff"
 				},
 				{
-					"ticks": 11867,
+					"ticks": 35601,
 					"value": "#ffffff"
 				},
 				{
-					"ticks": 13670,
+					"ticks": 41010,
 					"value": "#000000"
 				},
 				{
-					"ticks": 22330,
+					"ticks": 66990,
 					"value": "#000000"
 				}
 			],
@@ -200,19 +200,19 @@
 		"minecraft:visual/sky_light_color": {
 			"keyframes": [
 				{
-					"ticks": 730,
+					"ticks": 2190,
 					"value": "#ffffff"
 				},
 				{
-					"ticks": 11270,
+					"ticks": 33810,
 					"value": "#ffffff"
 				},
 				{
-					"ticks": 13140,
+					"ticks": 39420,
 					"value": "#7a7aff"
 				},
 				{
-					"ticks": 22860,
+					"ticks": 68580,
 					"value": "#7a7aff"
 				}
 			],
@@ -221,19 +221,19 @@
 		"minecraft:visual/sky_light_factor": {
 			"keyframes": [
 				{
-					"ticks": 730,
+					"ticks": 2190,
 					"value": 1
 				},
 				{
-					"ticks": 11270,
+					"ticks": 33810,
 					"value": 1
 				},
 				{
-					"ticks": 13140,
+					"ticks": 39420,
 					"value": 0.24
 				},
 				{
-					"ticks": 22860,
+					"ticks": 68580,
 					"value": 0.24
 				}
 			],
@@ -250,11 +250,11 @@
 			},
 			"keyframes": [
 				{
-					"ticks": 6000,
+					"ticks": 18000,
 					"value": 360
 				},
 				{
-					"ticks": 6000,
+					"ticks": 18000,
 					"value": 0
 				}
 			]
@@ -262,51 +262,51 @@
 		"minecraft:visual/star_brightness": {
 			"keyframes": [
 				{
-					"ticks": 92,
+					"ticks": 276,
 					"value": 0.037
 				},
 				{
-					"ticks": 627,
+					"ticks": 1881,
 					"value": 0
 				},
 				{
-					"ticks": 11373,
+					"ticks": 34119,
 					"value": 0
 				},
 				{
-					"ticks": 11732,
+					"ticks": 35196,
 					"value": 0.016
 				},
 				{
-					"ticks": 11959,
+					"ticks": 35877,
 					"value": 0.044
 				},
 				{
-					"ticks": 12399,
+					"ticks": 37197,
 					"value": 0.143
 				},
 				{
-					"ticks": 12729,
+					"ticks": 38187,
 					"value": 0.258
 				},
 				{
-					"ticks": 13228,
+					"ticks": 39684,
 					"value": 0.5
 				},
 				{
-					"ticks": 22772,
+					"ticks": 68316,
 					"value": 0.5
 				},
 				{
-					"ticks": 23032,
+					"ticks": 69096,
 					"value": 0.364
 				},
 				{
-					"ticks": 23356,
+					"ticks": 70068,
 					"value": 0.225
 				},
 				{
-					"ticks": 23758,
+					"ticks": 71274,
 					"value": 0.101
 				}
 			],
@@ -321,7 +321,7 @@
 					"value": 270
 				},
 				{
-					"ticks": 24000,
+					"ticks": 72000,
 					"value": 630
 				}
 			]
@@ -329,131 +329,131 @@
 		"minecraft:visual/sunrise_sunset_color": {
 			"keyframes": [
 				{
-					"ticks": 71,
+					"ticks": 213,
 					"value": "#5fefa333"
 				},
 				{
-					"ticks": 310,
+					"ticks": 930,
 					"value": "#29f5ba33"
 				},
 				{
-					"ticks": 565,
+					"ticks": 1695,
 					"value": "#06fbd433"
 				},
 				{
-					"ticks": 730,
+					"ticks": 2190,
 					"value": "#00ffe533"
 				},
 				{
-					"ticks": 11270,
+					"ticks": 33810,
 					"value": "#00ffe533"
 				},
 				{
-					"ticks": 11397,
+					"ticks": 34191,
 					"value": "#04fcd833"
 				},
 				{
-					"ticks": 11522,
+					"ticks": 34566,
 					"value": "#0ff9cb33"
 				},
 				{
-					"ticks": 11690,
+					"ticks": 35070,
 					"value": "#29f5ba33"
 				},
 				{
-					"ticks": 11929,
+					"ticks": 35787,
 					"value": "#5fefa333"
 				},
 				{
-					"ticks": 12243,
+					"ticks": 36729,
 					"value": "#b1e78733"
 				},
 				{
-					"ticks": 12358,
+					"ticks": 37074,
 					"value": "#cce47e33"
 				},
 				{
-					"ticks": 12512,
+					"ticks": 37536,
 					"value": "#e9e07233"
 				},
 				{
-					"ticks": 12613,
+					"ticks": 37839,
 					"value": "#f6dd6b33"
 				},
 				{
-					"ticks": 12732,
+					"ticks": 38196,
 					"value": "#feda6333"
 				},
 				{
-					"ticks": 12841,
+					"ticks": 38523,
 					"value": "#fed75c33"
 				},
 				{
-					"ticks": 13035,
+					"ticks": 39105,
 					"value": "#ecd25133"
 				},
 				{
-					"ticks": 13252,
+					"ticks": 39756,
 					"value": "#c1cc4733"
 				},
 				{
-					"ticks": 13775,
+					"ticks": 41325,
 					"value": "#36be3733"
 				},
 				{
-					"ticks": 13888,
+					"ticks": 41664,
 					"value": "#1fbb3533"
 				},
 				{
-					"ticks": 14039,
+					"ticks": 42117,
 					"value": "#09b73333"
 				},
 				{
-					"ticks": 14192,
+					"ticks": 42576,
 					"value": "#00b33333"
 				},
 				{
-					"ticks": 21807,
+					"ticks": 65421,
 					"value": "#00b23333"
 				},
 				{
-					"ticks": 21961,
+					"ticks": 65883,
 					"value": "#09b73333"
 				},
 				{
-					"ticks": 22112,
+					"ticks": 66336,
 					"value": "#1fbb3533"
 				},
 				{
-					"ticks": 22225,
+					"ticks": 66675,
 					"value": "#36be3733"
 				},
 				{
-					"ticks": 22748,
+					"ticks": 68244,
 					"value": "#c1cc4733"
 				},
 				{
-					"ticks": 22965,
+					"ticks": 68895,
 					"value": "#ecd25133"
 				},
 				{
-					"ticks": 23159,
+					"ticks": 69477,
 					"value": "#fed75c33"
 				},
 				{
-					"ticks": 23272,
+					"ticks": 69816,
 					"value": "#feda6333"
 				},
 				{
-					"ticks": 23488,
+					"ticks": 70464,
 					"value": "#e9e07233"
 				},
 				{
-					"ticks": 23642,
+					"ticks": 70926,
 					"value": "#cce47e33"
 				},
 				{
-					"ticks": 23757,
+					"ticks": 71271,
 					"value": "#b1e78733"
 				}
 			]

--- a/MF_datapack/data/minecraft/timeline/early_game.json
+++ b/MF_datapack/data/minecraft/timeline/early_game.json
@@ -1,0 +1,18 @@
+{
+  "clock": "minecraft:overworld",
+  "tracks": {
+    "minecraft:gameplay/can_pillager_patrol_spawn": {
+      "keyframes": [
+        {
+          "ticks": 0,
+          "value": false
+        },
+        {
+          "ticks": 360000,
+          "value": true
+        }
+      ],
+      "modifier": "and"
+    }
+  }
+}

--- a/MF_datapack/data/minecraft/timeline/moon.json
+++ b/MF_datapack/data/minecraft/timeline/moon.json
@@ -1,5 +1,5 @@
 {
-	"period_ticks": 192000,
+	"period_ticks": 576000,
 	"clock": "minecraft:overworld",
 	"tracks": {
 		"minecraft:gameplay/surface_slime_spawn_chance": {
@@ -10,31 +10,31 @@
 					"value": 0.5
 				},
 				{
-					"ticks": 24000,
-					"value": 0.375
-				},
-				{
-					"ticks": 48000,
-					"value": 0.25
-				},
-				{
 					"ticks": 72000,
-					"value": 0.125
-				},
-				{
-					"ticks": 96000,
-					"value": 0
-				},
-				{
-					"ticks": 120000,
-					"value": 0.125
+					"value": 0.375
 				},
 				{
 					"ticks": 144000,
 					"value": 0.25
 				},
 				{
-					"ticks": 168000,
+					"ticks": 216000,
+					"value": 0.125
+				},
+				{
+					"ticks": 288000,
+					"value": 0
+				},
+				{
+					"ticks": 360000,
+					"value": 0.125
+				},
+				{
+					"ticks": 432000,
+					"value": 0.25
+				},
+				{
+					"ticks": 504000,
 					"value": 0.375
 				}
 			],
@@ -47,35 +47,35 @@
 					"value": "full_moon"
 				},
 				{
-					"ticks": 12000,
+					"ticks": 36000,
 					"value": "waning_gibbous"
 				},
 				{
-					"ticks": 36000,
+					"ticks": 108000,
 					"value": "first_quarter"
 				},
 				{
-					"ticks": 60000,
+					"ticks": 180000,
 					"value": "waning_crescent"
 				},
 				{
-					"ticks": 84000,
+					"ticks": 252000,
 					"value": "new_moon"
 				},
 				{
-					"ticks": 108000,
+					"ticks": 324000,
 					"value": "waxing_crescent"
 				},
 				{
-					"ticks": 132000,
+					"ticks": 396000,
 					"value": "third_quarter"
 				},
 				{
-					"ticks": 156000,
+					"ticks": 468000,
 					"value": "waxing_gibbous"
 				},
 				{
-					"ticks": 180000,
+					"ticks": 540000,
 					"value": "full_moon"
 				}
 			]
@@ -89,7 +89,7 @@
 					"value": 90
 				},
 				{
-					"ticks": 192000,
+					"ticks": 576000,
 					"value": 2610
 				}
 			]

--- a/MF_datapack/data/minecraft/timeline/villager_schedule.json
+++ b/MF_datapack/data/minecraft/timeline/villager_schedule.json
@@ -1,0 +1,54 @@
+{
+  "clock": "minecraft:overworld",
+  "period_ticks": 72000,
+  "tracks": {
+    "minecraft:gameplay/baby_villager_activity": {
+      "keyframes": [
+        {
+          "ticks": 30,
+          "value": "minecraft:idle"
+        },
+        {
+          "ticks": 9000,
+          "value": "minecraft:play"
+        },
+        {
+          "ticks": 18000,
+          "value": "minecraft:idle"
+        },
+        {
+          "ticks": 30000,
+          "value": "minecraft:play"
+        },
+        {
+          "ticks": 36000,
+          "value": "minecraft:rest"
+        }
+      ]
+    },
+    "minecraft:gameplay/villager_activity": {
+      "keyframes": [
+        {
+          "ticks": 30,
+          "value": "minecraft:idle"
+        },
+        {
+          "ticks": 6000,
+          "value": "minecraft:work"
+        },
+        {
+          "ticks": 27000,
+          "value": "minecraft:meet"
+        },
+        {
+          "ticks": 33000,
+          "value": "minecraft:idle"
+        },
+        {
+          "ticks": 36000,
+          "value": "minecraft:rest"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #71 

Uses timelines for extending time instead of a function, since apparently that's had issues with running (Experienced it myself, running the load_day_cycle_extender function worked for me as well if I remember correctly)