### PR TITLE
Finished implementing Mass-Multiplayer support for Heart Container mechanics

### DIFF
--- a/MF_datapack/changelog.md
+++ b/MF_datapack/changelog.md
@@ -109,13 +109,18 @@ THESE ARE MY NOTES THEY AREN'T IMPORTANT BUT IM NOT PUTTING IT IN ANOTHER DOC
 
 # Scoreboards to be removed
 - apotropaic
-scoreboard players add copper_age Hearts 0
-scoreboard players add iron_age Hearts 0
-scoreboard players add diamond_age Hearts 0
-scoreboard players add nether_age Hearts 0
-scoreboard players add electrum_age Hearts 0
-scoreboard players add netherite_age Hearts 0
-scoreboard players add end_age Hearts 0
+- scoreboard players add copper_age Hearts 0
+- scoreboard players add iron_age Hearts 0
+- scoreboard players add diamond_age Hearts 0
+- scoreboard players add nether_age Hearts 0
+- scoreboard players add electrum_age Hearts 0
+- scoreboard players add netherite_age Hearts 0
+- scoreboard players add end_age Hearts 0
+- scoreboard players set 1 deaths 1
+- scoreboard players add current_minimum_hearts Hearts 0
+- scoreboard players set minimum_normal_hearts Hearts 12
+- scoreboard players set minimum_hard_hearts Hearts 6
+- scoreboard players set maximum_hearts Hearts 60
 
 # on_first_load
 - Use a scoreboard to determine if its really the first load

--- a/MF_datapack/data/matcha/function/mechanic/heart_container/decrease_minimum_hearts.mcfunction
+++ b/MF_datapack/data/matcha/function/mechanic/heart_container/decrease_minimum_hearts.mcfunction
@@ -1,28 +1,30 @@
-# Called when getting a "broken Heart" advancement (Ie. Obtaining, Iron, Copper, Diamond etc), only if its not in easy mode
-
-# if in Easy mode, do not run the rest of this function
-execute if score current_world_settings_difficulty difficulty_score matches 1 run return fail
-
+# Called when getting a "broken Heart" advancement (Ie. Obtaining, Iron, Copper, Diamond etc)
 
 scoreboard players remove @s minimum_hearts 2
 
+# If minimum hearts falls below the minimum for Normal difficulty, increase the difficulty IF it is in normal
+execute if score current_world_settings_difficulty difficulty_score matches 2 run execute if score @s minimum_hearts < $Normal minimum_hearts run function matcha:mechanic/difficulty_scaling/increase_difficulty
+
+# If player's minimum_hearts score is somehow below the minimum set for Hard difficulty, set it to that minimum and do not run the rest of this function
+execute if score @s minimum_hearts < $Hard minimum_hearts run return run scoreboard players operation @s minimum_hearts = $Hard minimum_hearts
+
 # Flavour Messages
-execute if score @s minimum_hearts matches 18 run tellraw @a {"color":"red","translate":"log.kleispack.god_grows_angry_1"}
-execute if score @s minimum_hearts matches 16 run tellraw @a {"color":"red","translate":"log.kleispack.god_grows_angry_2"}
-execute if score @s minimum_hearts matches 14 run tellraw @a {"color":"red","translate":"log.kleispack.god_grows_angry_3"}
-execute if score @s minimum_hearts matches 12 run tellraw @a {"color":"red","translate":"log.kleispack.god_grows_angry_4"}
+execute if score @s minimum_hearts matches 18 run tellraw @s {"color":"red","translate":"log.kleispack.god_grows_angry_1"}
+execute if score @s minimum_hearts matches 16 run tellraw @s {"color":"red","translate":"log.kleispack.god_grows_angry_2"}
+execute if score @s minimum_hearts matches 14 run tellraw @s {"color":"red","translate":"log.kleispack.god_grows_angry_3"}
+execute if score @s minimum_hearts matches 12 run tellraw @s {"color":"red","translate":"log.kleispack.god_grows_angry_4"}
 execute if score @s minimum_hearts matches 10 run tellraw @a {"color":"red","translate":"log.kleispack.god_grows_angry_5"}
-execute if score @s minimum_hearts matches 8 run tellraw @a {"color":"red","translate":"log.kleispack.god_grows_angry_6"}
-execute if score @s minimum_hearts matches 6 run tellraw @a {"color":"red","translate":"log.kleispack.god_grows_angry_7"}
+execute if score @s minimum_hearts matches 8 run tellraw @s {"color":"red","translate":"log.kleispack.god_grows_angry_6"}
+execute if score @s minimum_hearts matches 6 run tellraw @s {"color":"red","translate":"log.kleispack.god_grows_angry_7"}
+
+# If in Easy mode, do not say that minimum hearts has been decreased
+execute if score current_world_settings_difficulty difficulty_score matches 1 run return fail
 
 # Mechanic Messages
-execute if score @s minimum_hearts matches 18 run tellraw @a {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["9"]}
-execute if score @s minimum_hearts matches 16 run tellraw @a {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["8"]}
-execute if score @s minimum_hearts matches 14 run tellraw @a {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["7"]}
-execute if score @s minimum_hearts matches 12 run tellraw @a {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["6"]}
-execute if score @s minimum_hearts matches 10 run tellraw @a {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["5"]}
-execute if score @s minimum_hearts matches 8 run tellraw @a {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["4"]}
-execute if score @s minimum_hearts matches 6 run tellraw @a {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["3"]}
-
-# If minimum hearts is 5 increase the difficulty IF it is in normal
-execute if score current_world_settings_difficulty difficulty_score matches 2 run execute if score @s minimum_hearts matches 10 run function matcha:mechanic/difficulty_scaling/increase_difficulty
+execute if score @s minimum_hearts matches 18 run tellraw @s {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["9"]}
+execute if score @s minimum_hearts matches 16 run tellraw @s {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["8"]}
+execute if score @s minimum_hearts matches 14 run tellraw @s {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["7"]}
+execute if score @s minimum_hearts matches 12 run tellraw @s {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["6"]}
+execute if score @s minimum_hearts matches 10 run tellraw @s {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["5"]}
+execute if score @s minimum_hearts matches 8 run tellraw @s {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["4"]}
+execute if score @s minimum_hearts matches 6 run tellraw @s {"color":"gray","translate":"log.kleispack.minimum_heart_decreased","with":["3"]}

--- a/MF_datapack/data/matcha/function/mechanic/heart_container/set_max_hp.mcfunction
+++ b/MF_datapack/data/matcha/function/mechanic/heart_container/set_max_hp.mcfunction
@@ -1,11 +1,12 @@
 #Fallback, this shouldn't happen, but if somehow their score is set above the max, then set it to the maximum
-execute if score @s Hearts >= maximum_hearts Hearts store result score @s Hearts run scoreboard players get maximum_hearts Hearts
+execute if score @s Hearts >= $Max Hearts run scoreboard players operation @s Hearts = $Max Hearts
+
 
 #If they are on easy, we want to make sure it never goes below 10, HOWEVER, if they choose to go back to normal, we still want them to have that death consequence, thus:
-execute if score current_world_settings_difficulty difficulty_score matches 1 run execute if score @s Hearts < minimum_hearts Hearts store result score @s Hearts run scoreboard players get minimum_hearts Hearts
+execute if score current_world_settings_difficulty difficulty_score matches 1 run execute if score @s Hearts < $Easy minimum_hearts run scoreboard players operation @s Hearts = $Easy minimum_hearts
 
-#If they are NOT on easy, and they dip below the minimum, set it to the minimum (NamlessJu showed me how to set scores with another score! Thank you, Ju!!)
-execute if score current_world_settings_difficulty difficulty_score matches 2.. run execute if score @s Hearts < current_minimum_hearts Hearts store result score @s Hearts run scoreboard players get current_minimum_hearts Hearts
+#If they are NOT on easy, and they dip below their minimum, set it to their minimum
+execute if score current_world_settings_difficulty difficulty_score matches 2.. run execute if score @s Hearts < @s minimum_hearts run scoreboard players operation @s Hearts = @s minimum_hearts
 
 
 # Convert the player's Hearts score into a format that the Macro function can read

--- a/MF_datapack/data/matcha/function/setup/scoreboard.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/scoreboard.mcfunction
@@ -14,20 +14,28 @@ scoreboard players set 45 sneaking 45
 scoreboard objectives add Hunger food
 scoreboard objectives add HealthPoints health
 scoreboard objectives add deaths deathCount
-scoreboard players set 1 deaths 1
 
-# Setup "minimum_hearts" scoreboard
-scoreboard objectives add minimum_hearts dummy
-scoreboard players add @a minimum_hearts 0
 
 # Setup "Hearts" scoreboard
 scoreboard objectives add Hearts dummy
 scoreboard players add @a Hearts 0
 scoreboard players set @a[scores={Hearts=0}] Hearts 20
-scoreboard players add current_minimum_hearts Hearts 0
-scoreboard players set minimum_normal_hearts Hearts 12
-scoreboard players set minimum_hard_hearts Hearts 6
-scoreboard players set maximum_hearts Hearts 60
+
+# Global variables for "Hearts"
+# Because actual players will exist on this scoreboard, we add Special Characters to the variable names
+scoreboard players set $Max Hearts 60
+
+
+# Setup "minimum_hearts" scoreboard
+scoreboard objectives add minimum_hearts dummy
+scoreboard players add @a minimum_hearts 0
+
+# Global variables for "minimum_hearts"
+# Because actual players will exist on this scoreboard, we add Special Characters to the variable names
+scoreboard players set $Easy minimum_hearts 20
+scoreboard players set $Normal minimum_hearts 12
+scoreboard players set $Hard minimum_hearts 6
+
 
 # players' sleepTimer data value, and several other variables
 # related to sleeping stored in fake players
@@ -72,7 +80,7 @@ stopwatch create 2s
 stopwatch create 1s
 stopwatch create 0.5s
 
-#Used to clear xp after a cetain time after interacting with an anvil (cannot use schedule, as only the server can run schedule right now)
+#Used to clear xp after a certain time after interacting with an anvil (cannot use schedule, as only the server can run schedule right now)
 stopwatch create xp_timer
 
 #Used for village sounds

--- a/MF_datapack/data/matcha/function/setup/set_minimum_hearts_on_first_load.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/set_minimum_hearts_on_first_load.mcfunction
@@ -1,1 +1,0 @@
-scoreboard players set current_minimum_hearts Hearts 20


### PR DESCRIPTION
While editing the Heart Container functions I found partially implemented code for per-player Minimum-Heart values, which prevented the Heart Container system from fully functioning.

I have now finished what you started!

Mechanics wise:
* minimum_hearts are now tracked per-player instead of globally
* Messages from Advancements which decrease minimum hearts are now per player instead of global (Except the one which triggers Hard difficulty)
* On Easy difficulty minimum heart loss from advancements is tracked, but does not affect how low your max hp can get (But will be applied if you then set the difficulty to normal!).
* Flavour Messages from advancements now play on Easy, but Mechanic Messages won't

Code wise:
* Made the code more readable by using "scoreboard operation" to set scores with another score, instead of "execute store result"
* Values of the minimum hearts for each difficulty are now all tracked as global variables instead of being hard-coded, which makes them easier to change later, or even be changed on the fly.
* Added failsafe to prevent anyone's minimum hearts from dropping below the minimum set for Hard difficulty, this prevents player hearts from ever being set to 0 if something goes wrong.
* Removed unused setup/set_minimum_hearts_on_first_load function
* Removed unused scoreboards, noted in Changelog.md