### PR TITLE
ci(gh-actions): introduce Modrinth/GitHub README sync workflow

### DIFF
--- a/.github/assets/yt-playbutton.svg
+++ b/.github/assets/yt-playbutton.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="YouTube_Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" viewBox="0 0 1024 721" enable-background="new 0 0 1024 721" xml:space="preserve">
+<path id="Triangle" fill="#FFFFFF" d="M407,493l276-143L407,206V493z"/>
+<path id="The_Sharpness" opacity="0.12" fill="#420000" d="M407,206l242,161.6l34-17.6L407,206z"/>
+<g id="Lozenge">
+	<g>
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="512.5" y1="719.7" x2="512.5" y2="1.2" gradientTransform="matrix(1 0 0 -1 0 721)">
+			<stop  offset="0" style="stop-color:#E52D27"/>
+			<stop  offset="1" style="stop-color:#BF171D"/>
+		</linearGradient>
+		<path fill="url(#SVGID_1_)" d="M1013,156.3c0,0-10-70.4-40.6-101.4C933.6,14.2,890,14,870.1,11.6C727.1,1.3,512.7,1.3,512.7,1.3
+			h-0.4c0,0-214.4,0-357.4,10.3C135,14,91.4,14.2,52.6,54.9C22,85.9,12,156.3,12,156.3S1.8,238.9,1.8,321.6v77.5
+			C1.8,481.8,12,564.4,12,564.4s10,70.4,40.6,101.4c38.9,40.7,89.9,39.4,112.6,43.7c81.7,7.8,347.3,10.3,347.3,10.3
+			s214.6-0.3,357.6-10.7c20-2.4,63.5-2.6,102.3-43.3c30.6-31,40.6-101.4,40.6-101.4s10.2-82.7,10.2-165.3v-77.5
+			C1023.2,238.9,1013,156.3,1013,156.3z M407,493V206l276,144L407,493z"/>
+	</g>
+</g>
+</svg>

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -1,0 +1,169 @@
+name: Sync README from Modrinth
+
+on:
+  workflow_dispatch:
+  # Uncomment this section when tagged releases start occurring
+  # release:
+  #   types: [published]
+
+permissions:
+  contents: write # needed to push the README commit
+
+jobs:
+  sync-readme:
+    runs-on: ubuntu-latest
+    steps:
+      # A release checks out its tag (detached HEAD) by default, so check out the
+      # default branch instead. That's the branch the README commit gets pushed to.
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Fetch Modrinth project body into README.md
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+
+            const PROJECT_ID = 'QI0EmgZ1'; // Modrinth ID
+            const ASSETS = '.github/assets';
+            const PLAY_BUTTON = `${ASSETS}/yt-playbutton.svg`;
+
+            // YouTube's player draws its play button at a fixed 68x48, centered on the video
+            const BUTTON_W = 68;
+            const BUTTON_H = 48;
+
+            // Title + author in the top left, sized like the YT embed (y values are the text baselines)
+            const SHADE_H = 96;
+            const TEXT_X = 12;
+            const TITLE_Y = 30;
+            const TITLE_SIZE = 18;
+            const AUTHOR_Y = 50;
+            const AUTHOR_SIZE = 13;
+            const FONT = 'Roboto, Arial, Helvetica, sans-serif';
+
+            const res = await fetch(`https://api.modrinth.com/v2/project/${PROJECT_ID}`, {
+              headers: { 'User-Agent': `${context.repo.owner}/${context.repo.repo} (GitHub Actions)` },
+            });
+            if (!res.ok) {
+              core.setFailed(`Modrinth API returned ${res.status} ${res.statusText}`);
+              return;
+            }
+            const { body } = await res.json();
+
+            // Best available thumbnail as base64. Not every video has a maxresdefault.
+            async function thumbnail(id) {
+              for (const name of ['maxresdefault', 'hqdefault']) {
+                const r = await fetch(`https://i.ytimg.com/vi/${id}/${name}.jpg`);
+                if (r.ok) return Buffer.from(await r.arrayBuffer()).toString('base64');
+              }
+              throw new Error(`No thumbnail found for YouTube video ${id}`);
+            }
+
+            // YT's oEmbed gives us the title + author, no API calls
+            // If it fails (private video, embeds turned off) we just skip the title
+            async function videoInfo(id) {
+              const url = encodeURIComponent(`https://www.youtube.com/watch?v=${id}`);
+              try {
+                const r = await fetch(`https://www.youtube.com/oembed?format=json&url=${url}`);
+                if (r.ok) return await r.json();
+                core.warning(`oEmbed returned ${r.status} for ${id}, skipping the title`);
+              } catch (e) {
+                core.warning(`oEmbed failed for ${id} (${e.message}), skipping the title`);
+              }
+              return null;
+            }
+
+            const escapeXml = (s) => s.replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
+
+            // svg text won't cut itself off, so roughly measure it and add a "…"
+            const charWidth = (c) =>
+              c.codePointAt(0) > 0x2000 ? 1 :
+              /[ilIjft.,:;'|!()[\] ]/.test(c) ? 0.3 :
+              /[mwMW@%]/.test(c) ? 0.85 :
+              /[A-Z0-9#&?]/.test(c) ? 0.65 : 0.52;
+            const textWidth = (chars, px) => chars.reduce((sum, c) => sum + charWidth(c) * px, 0);
+            function fit(text, px, maxWidth) {
+              const chars = [...text];
+              if (textWidth(chars, px) <= maxWidth) return text;
+              while (chars.length && textWidth([...chars, '…'], px) > maxWidth) chars.pop();
+              return `${chars.join('').trimEnd()}…`;
+            }
+
+            // Reads the iframe's width/height attribute, falling back to YouTube's default embed size
+            const size = (tag, attr, fallback) =>
+              Number(tag.match(new RegExp(`\\s${attr}=["']?(\\d+)["']?(?=[\\s/>])`, 'i'))?.[1] ?? fallback);
+
+            // We need to replace the <iframe> that is removed by github, and replace it with a
+            // custom <img> using the YT thumbnail + playbutton .svg
+            const embeds = [...body.matchAll(
+              /<iframe\b[^>]*\bsrc=["']https?:\/\/(?:www\.)?youtube(?:-nocookie)?\.com\/embed\/([\w-]{11})[^>]*>\s*<\/iframe>/gi
+            )];
+
+            let readme = body;
+            if (embeds.length) {
+              const playButton = fs.readFileSync(PLAY_BUTTON).toString('base64');
+
+              for (const [tag, id] of embeds) {
+                const w = size(tag, 'width', 560);
+                const h = size(tag, 'height', 315);
+                const thumb = await thumbnail(id);
+                const info = await videoInfo(id);
+                const textMax = w - TEXT_X * 2;
+
+                // Black to transparent fade at the top so the text is readable
+                const titleBar = !info ? [] : [
+                  `  <defs>`,
+                  `    <linearGradient id="shade" x1="0" y1="0" x2="0" y2="1">`,
+                  `      <stop offset="0" stop-color="#000" stop-opacity="0.6"/>`,
+                  `      <stop offset="0.35" stop-color="#000" stop-opacity="0.32"/>`,
+                  `      <stop offset="0.7" stop-color="#000" stop-opacity="0.1"/>`,
+                  `      <stop offset="1" stop-color="#000" stop-opacity="0"/>`,
+                  `    </linearGradient>`,
+                  `    <filter id="text-shadow"><feDropShadow dx="0" dy="0" stdDeviation="1" flood-opacity="0.5"/></filter>`,
+                  `  </defs>`,
+                  `  <rect width="${w}" height="${SHADE_H}" fill="url(#shade)"/>`,
+                  `  <g font-family="${FONT}" fill="#fff" filter="url(#text-shadow)">`,
+                  `    <text x="${TEXT_X}" y="${TITLE_Y}" font-size="${TITLE_SIZE}" font-weight="500">${escapeXml(fit(info.title, TITLE_SIZE, textMax))}</text>`,
+                  `    <text x="${TEXT_X}" y="${AUTHOR_Y}" font-size="${AUTHOR_SIZE}" fill-opacity="0.8">${escapeXml(fit(info.author_name, AUTHOR_SIZE, textMax))}</text>`,
+                  `  </g>`,
+                ];
+
+                // "slice" fills the frame and crops the black bars hqdefault thumbnails have
+                const svg = [
+                  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} ${h}" width="${w}" height="${h}">`,
+                  `  <image href="data:image/jpeg;base64,${thumb}" width="${w}" height="${h}" preserveAspectRatio="xMidYMid slice"/>`,
+                  ...titleBar,
+                  `  <image href="data:image/svg+xml;base64,${playButton}" x="${(w - BUTTON_W) / 2}" y="${(h - BUTTON_H) / 2}" width="${BUTTON_W}" height="${BUTTON_H}"/>`,
+                  `</svg>`,
+                  ``,
+                ].join('\n');
+
+                const file = `${ASSETS}/yt-${id}.svg`;
+                fs.writeFileSync(file, svg);
+                core.info(`Wrote ${file}`);
+
+                readme = readme.replace(tag, () =>
+                  `<p align="center"><a href="https://www.youtube.com/watch?v=${id}">` +
+                  `<img src="${file}" alt="Watch on YouTube" width="${w}"></a></p>`
+                );
+              }
+            }
+
+            fs.writeFileSync('README.md', `${readme}\n`);
+            core.info(`Wrote ${readme.length} characters to README.md`);
+
+      - name: Commit and push README
+        env:
+          TAG: ${{ github.event.release.tag_name || 'manual run' }}
+        run: |
+          if [ -z "$(git status --porcelain -- README.md .github/assets)" ]; then
+            echo "README.md is already up to date, nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md .github/assets
+          git commit -m "docs(readme): sync README from Modrinth ($TAG)"
+          git push


### PR DESCRIPTION
Hello! Just wanted to say huge fan of the modpack :) Appreciate the love and work that you're putting in to Matcha Flavoured.

I came by to checkout the repo to see if there is anything that perhaps could be helped with. I was surprised to find the `README.md` file for this repo very bare, comapred to what was posted on Modrinth, so I went ahead and typed up with `sync-readme.yml` GitHub Action flow that can be activated using a Manual Button press on the Actions page. (This can be modified later to be automated).

I was checking out other issues that were open, and saw that #82 Is trying to do the same thing, but for automating datapack releases. This is somewhat an addition of that, in terms of getting a good CI/CD pipeline started.

With this, you only need to update the README on Modrinth, and then run this action to replace it in this repo.

This PR proposes a single, easy commit that does the following:

1. Checks out the latest version of the `main` branch on this repo.
2. Runs very basic JavaScript to fetch the Matcha Flavoured project info using the Modrinth API.
3. Grab the body (README) of the Modrinth Project, and extract it's Markdown.
4. Replace the `<iframe>` of the YouTube video from the Modrinth description with a copy of it's Thumbnail via the YouTube JSON data, and overlay a play button logo + video title/author name at the top-left, and make it a clickable Markdown link.
5. Then commits the README to the `main` branch of the repo.

I personally think leaving the video in here is way better than replacing it with a simple link.

Great thing about the YT thumbnail generator is that if you change the title/thumbnail or add, edit, modify more videos, those will be replicated here as well.

Let me know if you have any questions or would like some things reviewed.

*Ideally*, if this repo would ever switch to a tagged release, or GitHub Action-focused releases, this can be automated to run immediately after the .zip file is created, removing the need to manually sync any `README.md` updates, or copy/paste the same information twice across different platforms. Plus, this workflow could be modified to include any other wanted/generated info -- but for now is only the Modrinth data.

### Screenshots

1. (`README` after Modrinth sync)

<img width="1208" height="902" alt="Screenshot 2026-09-11 at 7 23 42 PM" src="https://github.com/user-attachments/assets/c880edc2-afbb-436d-b9b4-4991b9a24518" />

2. (Generated Thumbnail)

<img width="560" height="315" alt="image" src="https://github.com/user-attachments/assets/fb95e6b3-4d62-4725-8d59-4c3e3fb7d236" />

3. (Thumbnail location in the `README`)

<img width="862" height="559" alt="Screenshot 2026-09-11 at 7 28 03 PM" src="https://github.com/user-attachments/assets/4aa9675a-62a5-4cfd-9175-231bd1ef66ee" />


---

### Changelog

- create/merge `.github/workflows` directory, as there is none (as of the latest commit: 95eb292)
- create `sync-readme.yml` GitHub Action workflow that allows the GitHub repo `README.md` file to mirror the one that is on Modrinth's project page.
- import `yt-playbutton.svg` image for YouTube thumbnail fixes, because GitHub does not allow embedded <iframe>'s in readme files, so we need to manually create a YT thumbnail to go in the place of the Youtube trailer video.