### PR TITLE
Fix sleep regression caused by switch to timeline for day cycle extension

### DIFF
--- a/MF_datapack/data/matcha/function/mechanic/sleeping/calculate_sleep_duration.mcfunction
+++ b/MF_datapack/data/matcha/function/mechanic/sleeping/calculate_sleep_duration.mcfunction
@@ -1,14 +1,16 @@
+# note: everything in here has been multiplied by 3 as per #83
+
 # calculate sleep duration (gametime to skip before kicking out of bed)
 # default to 12000, but should be less if going to bed after nightfall so that
 # players wake up in the morning
 
-scoreboard players set @s sleepDuration 12000
+scoreboard players set @s sleepDuration 36000
 
 #check time of day
 execute store result score current_time sleepTimerScore run time query day
-execute unless score current_time sleepTimerScore matches 12000..23000 run return 0
+execute unless score current_time sleepTimerScore matches 36000..69000 run return 0
 
 #only executes if current_time is between 12000 and 23000 (night time)
 #subtract elapsed night time from sleep duration so player wakes up in the morning
-scoreboard players set @s sleepDuration 24000
+scoreboard players set @s sleepDuration 72000
 scoreboard players operation @s sleepDuration -= current_time sleepTimerScore

--- a/MF_datapack/data/matcha/function/mechanic/sleeping/calculate_sleep_rate.mcfunction
+++ b/MF_datapack/data/matcha/function/mechanic/sleeping/calculate_sleep_rate.mcfunction
@@ -1,3 +1,5 @@
+# note: everything in here has been multiplied by 3 as per #83
+
 # count number of players in overworld
 execute store result score players_in_overworld sleepTimerScore \
     if entity @a[predicate=matcha:in_overworld]
@@ -11,9 +13,9 @@ execute store result score players_sleeping sleepTimerScore \
 # calculate sleep rate (amount of time to skip per tick)
 #
 # formula:
-#  sleep_rate = (players_sleeping/players_in_overworld)^2 * 100
+#  sleep_rate = (players_sleeping/players_in_overworld)^2 * 300
 #
-scoreboard players set sleep_rate sleepTimerScore 100
+scoreboard players set sleep_rate sleepTimerScore 300
 scoreboard players operation sleep_rate sleepTimerScore *= players_sleeping sleepTimerScore
 scoreboard players operation sleep_rate sleepTimerScore *= players_sleeping sleepTimerScore
 scoreboard players operation sleep_rate sleepTimerScore /= players_in_overworld sleepTimerScore


### PR DESCRIPTION
Fixes #94 

Since the game clock was multiplied by 3 times, sleep which relies on that game clock very much should have also received the same treatment. It has now received the same treatment. Tested on my own test world.