### PR TITLE
Improvements to Scoreboard handling & Multiplayer Support fix

### DIFF
--- a/MF_datapack/data/matcha/advancement/tutorial/root.json
+++ b/MF_datapack/data/matcha/advancement/tutorial/root.json
@@ -17,8 +17,5 @@
 		"tick": {
 			"trigger": "minecraft:tick"
 		}
-	},
-	"rewards": {
-		"function": "matcha:setup/on_first_load/on_first_load"
 	}
 }

--- a/MF_datapack/data/matcha/function/setup/load.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/load.mcfunction
@@ -1,5 +1,8 @@
-# Set up functions
-function matcha:setup/scoreboard
+# Set required Gamerules
+function matcha:setup/gamerules
+
+# Set up Scoreboards
+function matcha:setup/scoreboard/create_scoreboards
 
 # Print information to players
 tellraw @a {"bold":false,"color":"#65E082","translate":"log.kleispack.now_loaded","with":["1.12.1"]}

--- a/MF_datapack/data/matcha/function/setup/on_first_load/on_first_load.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/on_first_load/on_first_load.mcfunction
@@ -1,2 +1,0 @@
-function matcha:setup/gamerules
-function matcha:setup/on_first_load/scoreboard

--- a/MF_datapack/data/matcha/function/setup/on_first_load/scoreboard.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/on_first_load/scoreboard.mcfunction
@@ -1,1 +1,0 @@
-scoreboard players set @s minimum_hearts 20

--- a/MF_datapack/data/matcha/function/setup/player_update_check_loop.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/player_update_check_loop.mcfunction
@@ -7,7 +7,7 @@
 
 
 # If the player's version number is less than the current version, run the amnesia function (remove all recipe unlock advancements)
-execute as @a if score @s version_number < current_version version_number run function matcha:setup/update_this_player
+execute as @a unless score @s version_number >= current_version version_number run function matcha:setup/update_this_player
 
 # Run this checker again in one second's time
 schedule function matcha:setup/player_update_check_loop 1s replace

--- a/MF_datapack/data/matcha/function/setup/scoreboard/create_scoreboards.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/scoreboard/create_scoreboards.mcfunction
@@ -1,5 +1,8 @@
+# This function runs when the Datapack is Loaded
+# This function is used to set up Scoreboards and their Global Variables
+# Players' initial scores are applied in "matcha:setup/scoreboard/player_setup"
+
 scoreboard objectives add sneaking minecraft.custom:minecraft.sneak_time
-scoreboard players add @a sneaking 0
 scoreboard players set 0 sneaking 0
 scoreboard players set 5 sneaking 5
 scoreboard players set 10 sneaking 10
@@ -18,8 +21,6 @@ scoreboard objectives add deaths deathCount
 
 # Setup "Hearts" scoreboard
 scoreboard objectives add Hearts dummy
-scoreboard players add @a Hearts 0
-scoreboard players set @a[scores={Hearts=0}] Hearts 20
 
 # Global variables for "Hearts"
 # Because actual players will exist on this scoreboard, we add Special Characters to the variable names
@@ -28,7 +29,6 @@ scoreboard players set $Max Hearts 60
 
 # Setup "minimum_hearts" scoreboard
 scoreboard objectives add minimum_hearts dummy
-scoreboard players add @a minimum_hearts 0
 
 # Global variables for "minimum_hearts"
 # Because actual players will exist on this scoreboard, we add Special Characters to the variable names
@@ -99,9 +99,9 @@ scoreboard players set 0 anvil_interaction 0
 scoreboard objectives add water_bucket_used minecraft.used:minecraft.water_bucket
 scoreboard players set 1 water_bucket_used 1
 
-#On load, set the wandering trader timer, and reset ALL people who summoned him, becuase if we dont, functions that should be looping wont be
-#and itll never ever fix itself. So if the server crashes, or someone logs out whilst waiting, they will never have a wandering trader arrive :c
-#We will also kill any existing wandering traders, on load. Because again, thatll mess things up
+# On load, set the wandering trader timer, and reset ALL people who summoned him, because if we don't, functions that should be looping wont be
+# and it'll never ever fix itself. So if the server crashes, or someone logs out whilst waiting, they will never have a wandering trader arrive :c
+# We will also kill any existing wandering traders, on load. Because again, that'll mess things up
 function matcha:mechanic/wandering_trader/kill_wandering_trader_early
 scoreboard objectives add wandering_trader_timer_score dummy
 scoreboard players reset @a wandering_trader_timer_score

--- a/MF_datapack/data/matcha/function/setup/scoreboard/player_setup.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/scoreboard/player_setup.mcfunction
@@ -1,0 +1,11 @@
+# This function is called by the "matcha:setup/update_this_player" function
+# This function is run once by each new player in the world, or by each player which last joined the world on an earlier version of Matcha
+# This function sets up initial scores for mechanics which require a starting score that isn't null(no score) to work
+
+scoreboard players add @s sneaking 0
+
+# If player's minimum hearts score is below the minimum for Hard, they must either have no score or an invalid one, so set it to the default of 20
+execute unless score @s minimum_hearts >= $Hard minimum_hearts run scoreboard players set @s minimum_hearts 20
+
+# Sync Hearts value with player's max hp
+execute store result score @s Hearts run attribute @s minecraft:max_health get

--- a/MF_datapack/data/matcha/function/setup/update_this_player.mcfunction
+++ b/MF_datapack/data/matcha/function/setup/update_this_player.mcfunction
@@ -1,5 +1,6 @@
-#Revoke root adv, so that on_first_load functions run
-advancement revoke @s only matcha:tutorial/root
+# Since this runs immediately for every newly joined player, we don't need to use an advancement to trigger "on_first_load" functions, we just run them here.
+# Set up scoreboard scores
+function matcha:setup/scoreboard/player_setup
 
 # For a new version, we wipe their recipe unlock advancements so they can learn new things that were added or tweaked (or bugged)
 advancement revoke @s from minecraft:recipes/root
@@ -28,4 +29,4 @@ stopwatch remove minecraft:divinity30s
 scoreboard players operation @s version_number = current_version version_number
 
 # Announce that a player has been updated
-tellraw @a ["",{"text":"[!]","bold":true,"color":"green"},{"text":": ","color":"green"},{"translate":"log.kleispack.player_updated","color":"gray"}]
+tellraw @a [{"text":"[!]","bold":true,"color":"green"},{"text":": ","color":"green"},{"translate":"log.kleispack.player_updated","color":"gray"}]


### PR DESCRIPTION
Cleaned up some code spaghetti which had formed around the setup functions.

All "global" setup that is done per-world is now ran by load.mcfunction . All setup which is done per-player is now ran by update_this_player.mcfunction .

I've split the scoreboard setup function into two functions nested in the "setup/scoreboard" folder:
* "matcha:setup/scoreboard/create_scoreboards" for setting up the scoreboards themselves and their global variables (which is run by load.mcfunction)
* "matcha:setup/scoreboard/player_setup" for giving players an initial score for mechanics which require a score to be present in order to work (which is run by update_this_player.mcfunction)

Gamerules are now set on load.mcfunction, as they are per-world

I fixed an error I made that was preventing players without a version number from being updated by update_this_player.mcfunction (my bad)

Removed:
* "on_first_load" functions, as they are now covered by update_this_player.mcfunction
* The advancement trigger for "on_first_load", this is now done by player_update_check_loop.mcfunction
* scoreboard.mcfunction, as it's now split into the two new functions mentioned above