### PR TITLE
Fixed error in Deepslate Iron Ore's Loot Table

### DIFF
--- a/MF_datapack/data/minecraft/loot_table/blocks/deepslate_iron_ore.json
+++ b/MF_datapack/data/minecraft/loot_table/blocks/deepslate_iron_ore.json
@@ -1,92 +1,91 @@
 {
-	"type": "minecraft:block",
-	"pools": [
-		{
-			"bonus_rolls": 0,
-			"entries": [
-				{
-					"type": "minecraft:alternatives",
-					"children": [
-						{
-							"type": "minecraft:item",
-							"conditions": [
-								{
-									"condition": "minecraft:match_tool",
-									"predicate": {
-										"predicates": {
-											"minecraft:enchantments": [
-												{
-													"enchantments": "minecraft:silk_touch",
-													"levels": {
-														"min": 1
-													}
-												}
-											]
-										}
-									}
-								}
-							],
-							"name": "minecraft:deepslate_iron_ore"
-						},
-						{
-							"type": "minecraft:item",
-							"conditions": [
-								{
-									"condition": "minecraft:match_tool",
-									"predicate": {
-										"predicates": {
-											"minecraft:enchantments": [
-												{
-													"enchantments": "matcha:adamant_tool"
-												}
-											]
-										}
-									}
-								}
-							],
-							"functions": [
-								{
-									"function": "minecraft:set_count",
-									"count": 2
-								},
-								{
-									"function": "minecraft:apply_bonus",
-									"enchantment": "matcha:electrum_tool",
-									"formula": "minecraft:uniform_bonus_count"
-								},
-								{
-									"enchantment": "minecraft:fortune",
-									"formula": "minecraft:ore_drops",
-									"function": "minecraft:apply_bonus"
-								}
-							],
-							"name": "minecraft:iron_ingot"
-						},
-						{
-							"type": "minecraft:item",
-							"functions": [
-								{
-									"function": "minecraft:set_count",
-									"count": 2
-								},
-								{
-									"enchantment": "minecraft:fortune",
-									"formula": "minecraft:ore_drops",
-									"function": "minecraft:apply_bonus"
-								},
-								{
-									"function": "minecraft:apply_bonus",
-									"enchantment": "matcha:electrum_tool",
-									"formula": "minecraft:ore_drops"
-								}
-							],
-							"name": "minecraft:raw_iron"
-						}
-					]
-				}
-			],
-			"rolls": 1
-		}
-	],
-	"random_sequence": "minecraft:blocks/deepslate_iron_ore"
+  "type": "minecraft:block",
+  "random_sequence": "minecraft:blocks/deepslate_iron_ore",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "name": "minecraft:deepslate_iron_ore",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "type": "minecraft:item",
+              "name": "minecraft:iron_ingot",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "matcha:adamant_tool"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "functions": [
+                {
+                  "function": "minecraft:set_count",
+                  "count": 2
+                },
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "matcha:electrum_tool",
+                  "formula": "minecraft:ore_drops"
+                },
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:ore_drops"
+                }
+              ]
+            },
+            {
+              "type": "minecraft:item",
+              "name": "minecraft:raw_iron",
+              "functions": [
+                {
+                  "function": "minecraft:set_count",
+                  "count": 2
+                },
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:ore_drops"
+                },
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "matcha:electrum_tool",
+                  "formula": "minecraft:ore_drops"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Fixes https://github.com/kleiwright/matcha-flavoured/issues/99

the apply_bonus function for electrum tool was set to "uniform_bonus_count" instead of "ore_drops"